### PR TITLE
Revert manual publish dispatch change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,6 @@ jobs:
       - name: Check if version changed
         id: check_version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            curr_version=$(node -p "require('./package.json').version")
-            echo "Manual publish requested for $curr_version. Proceeding with publish."
-            echo "changed=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
           # 取得前一個 commit 的版本號
           prev_version=$(git show HEAD~1:package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || echo "none")
           # 取得目前的版本號

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quick-prompt",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quick-prompt",
-            "version": "0.4.3",
+            "version": "0.4.4",
             "license": "MIT",
             "dependencies": {
                 "@huggingface/transformers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "quick-prompt",
     "displayName": "Quick Prompt - Capture Ideas & Queue Tasks While AI Works",
     "description": "%extension.description%",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "publisher": "winterdrive",
     "icon": "docs/assets/quickprompt_icon_128.png",
     "license": "MIT",


### PR DESCRIPTION
This reverts the unnecessary publish workflow change from f669986. The original CI failure was fixed by preserving the ClipboardManager filename casing; the release workflow should not be changed just to republish the same version. Future publish retries should go through the normal version bump/release path.