### PR TITLE
chore: support routine maintenance PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- Briefly describe what changed and why. -->
+
+## Pre-flight Check
+
+- Open PRs / active branches checked:
+- Overlap assessment:
+- Routine PR: yes / no
+
+## Changes
+
+- 
+
+## Safety Verification
+
+- [ ] `npx tsc -p ./`
+- [ ] `npm run test`
+- [ ] `npm run test:coverage`
+- [ ] Other:
+
+## Routine PR Notes
+
+For daily routine Draft PRs:
+
+- Do not bump `package.json` or `package-lock.json`.
+- Do not update `CHANGELOG.md`.
+- Do not modify MCP tool schemas, names, or parameters under `mcp-server/src/tools/`.
+- Package version bump and changelog consolidation are deferred to the weekend release/integration PR.
+- If GitHub Actions fails only because of the release version gate, treat that as release-readiness behavior, not a code validation failure.
+
+## Release Readiness
+
+- [ ] This PR is labeled `release-ready` only when version and changelog updates are intentionally included.

--- a/.github/workflows/label-routine-pr.yml
+++ b/.github/workflows/label-routine-pr.yml
@@ -1,0 +1,25 @@
+name: Label Routine PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  label-routine:
+    if: startsWith(github.event.pull_request.title, '[Routine - QP]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add routine label
+        run: gh pr edit "$PR_URL" --add-label routine
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,13 @@ name: Validate Extension
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
     branches:
       - master
   push:
@@ -31,8 +38,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate version bump
-        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      - name: Validate release version bump
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'release-ready')
         run: |
           git fetch origin "${{ github.base_ref }}"
           changed_files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ dist-test/
 .gemini/skills/edo-tensei/
 .cursor/rules/edo-tensei.mdc
 prompts.json
-AGENTS.md
 debug.log
+routine_fail.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+- 任務報告或規劃文件皆優先以中文撰寫。
+- Daily routine Draft PR 不做 release 準備：不要 bump `package.json` / `package-lock.json`，不要更新 `CHANGELOG.md`。
+- 不可修改 `mcp-server/src/tools/` 內任何 tool schema、tool name 或參數，避免破壞既有 MCP client。
+- 不可新增、移除或更新 dependencies，除非使用者明確要求 dependency/security work。
+- 文件修正不可只改使用者指出的單一檔案。若問題屬於同源文案、release-facing docs、README、多語文件或 llms 文件，必須先用 `rg` 掃 `README.md`、`docs/`、`llms*.txt` 找出同類問題，列出 scope 後一起修正，改完再反向 `rg` 驗證舊口徑不存在。

--- a/docs/maintainer-routine.md
+++ b/docs/maintainer-routine.md
@@ -1,0 +1,36 @@
+# Maintainer Routine
+
+This repository supports small daily routine Draft PRs and separate weekend release/integration PRs.
+
+## Daily Routine Draft PRs
+
+Daily routine PRs should stay small and easy to review.
+
+- Fix one small, safe issue.
+- Avoid duplicate work by checking open PRs and active routine branches first.
+- Do not bump `package.json` or `package-lock.json`.
+- Do not update `CHANGELOG.md`.
+- Do not modify MCP tool schemas, names, or parameters under `mcp-server/src/tools/`.
+- Do not add, remove, or update dependencies.
+- Keep the PR as Draft until it is intentionally selected for integration.
+
+Run local validation before opening the Draft PR:
+
+```powershell
+npx tsc -p ./
+npm run test
+npm run test:coverage
+```
+
+If a routine attempt fails after focused fixes, write the failure summary to `routine_fail.log`. That file is ignored by Git.
+
+## Release/Integration PRs
+
+Weekend release or integration PRs are responsible for release metadata.
+
+- Consolidate selected routine PRs.
+- Bump `package.json` and `package-lock.json` once.
+- Update `CHANGELOG.md`.
+- Add the `release-ready` label when the PR is ready for release version validation.
+
+The release version gate in CI runs only for pull requests labeled `release-ready`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,8 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     testMatch: ['**/src/test/**/*.test.ts'],
-    testPathIgnorePatterns: ['/node_modules/', '/src/test/ui/', '/.vscode-test/'],
-    modulePathIgnorePatterns: ['<rootDir>/.vscode-test/', '<rootDir>/dist/'],
+    testPathIgnorePatterns: ['/node_modules/', '/src/test/ui/', '/.vscode-test/', '/.claude/', '/.cursor/', '/.kiro/'],
+    modulePathIgnorePatterns: ['<rootDir>/.vscode-test/', '<rootDir>/dist/', '<rootDir>/.claude/', '<rootDir>/.cursor/', '<rootDir>/.kiro/'],
     transform: {
         '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
     },

--- a/package.json
+++ b/package.json
@@ -610,6 +610,7 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run build:qp && npm run build:mcp && tsc -p ./ && npm run build:skills",
+        "clean": "node -e \"const fs=require('fs');for (const p of ['dist','out']) fs.rmSync(p,{recursive:true,force:true})\"",
         "build": "npm run clean && tsc -p ./ && npm run build:qp && npm run build:mcp && npm run build:skills",
         "build:skills": "node -e \"const fs=require('fs');fs.mkdirSync('dist/skills/quickprompt',{recursive:true});fs.copyFileSync('skills/quickprompt/SKILL.md','dist/skills/quickprompt/SKILL.md');fs.mkdirSync('skills/quickprompt/scripts',{recursive:true});fs.copyFileSync('dist/qp.bundle.js','skills/quickprompt/scripts/qp.bundle.js')\"",
         "_trigger_publish": "echo 'Triggering publish workflow'",


### PR DESCRIPTION
## Summary

Adds repository support for daily routine maintenance PRs and separates release readiness from normal validation.

## Changes

- Runs the release version bump gate only when a PR has the release-ready label.
- Adds an automatic routine label workflow for PR titles starting with [Routine - QP].
- Adds a PR template and maintainer routine documentation.
- Tracks AGENTS.md with routine PR guardrails.
- Ignores routine_fail.log.
- Adds the missing clean script used by npm run build.
- Ignores local agent/worktree folders in Jest discovery.

## Safety Verification

- package.json parse check passed.
- git diff --check passed.
- npx tsc -p ./ passed.
- npm run test:coverage passed: 6 suites / 100 tests.

## Release Gate Note

Do not add release-ready to routine Draft PRs. Add it only to weekend release/integration PRs that intentionally include version and changelog updates.