### PR TITLE
chore: prepare Quick Prompt 0.5.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the "Quick Prompt" extension will be documented in this file.
 
+## [0.5.7] - Stability Fixes - 2026-07-02
+
+### Stability
+
+- Guard clipboard history loading against valid JSON payloads that are not arrays, falling back to an empty history instead of throwing later during clipboard updates.
+- Guard prompt loading against non-array `prompts.json` payloads and keep the existing backup-and-reset recovery path explicit and tested.
+- Guard version history loading against corrupted JSON and malformed history objects, resetting to an empty history instead of breaking tree rendering or migration for later prompts.
+- Ensure local Qwen progress notifications are cleaned up when worker initialization fails, and handle the `withProgress` rejection path to avoid unhandled promise warnings.
+
+### Maintenance
+
+- Replace deprecated `String.prototype.substr()` usage with equivalent `substring()` calls in privacy and version helpers.
+- Remove an unused `reply` assignment from the OpenAI-compatible connection test path.
+- Added unit coverage for clipboard history, prompt loading, and version history malformed-data recovery paths.
+
 ## [0.5.6] - Multi-root Select Scope - 2026-06-24
 
 ### 🗂 Multi-root Select Scope

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quick-prompt",
-    "version": "0.5.5",
+    "version": "0.5.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quick-prompt",
-            "version": "0.5.5",
+            "version": "0.5.7",
             "license": "MIT",
             "dependencies": {
                 "@huggingface/transformers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "quick-prompt",
     "displayName": "Quick Prompt - Capture Ideas & Queue Tasks While AI Works",
     "description": "%extension.description%",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "publisher": "winterdrive",
     "icon": "docs/assets/quickprompt_icon_128.png",
     "license": "MIT",

--- a/skills/quickprompt/scripts/qp.bundle.js
+++ b/skills/quickprompt/scripts/qp.bundle.js
@@ -139,7 +139,12 @@ var PromptManager = class {
     }
     try {
       const content = fs2.readFileSync(this.promptsFilePath, "utf-8");
-      const prompts = JSON.parse(content);
+      const parsed = JSON.parse(content);
+      if (!Array.isArray(parsed)) {
+        this.createBackup();
+        return { prompts: [], version: 0 };
+      }
+      const prompts = parsed;
       const version = PathUtils.getMtime(this.promptsFilePath);
       const today = (/* @__PURE__ */ new Date()).toISOString().split("T")[0];
       const normalized = prompts.map((p) => ({
@@ -571,7 +576,7 @@ var VersionManager = class {
     return path3.join(this.historyDir, `${safeId}.history.json`);
   }
   generateVersionId() {
-    return `v${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    return `v${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
   }
   pruneVersions(history) {
     while (history.versions.length > PROMPT_CONSTANTS.MAX_VERSIONS) {

--- a/src/ClipboardManager.ts
+++ b/src/ClipboardManager.ts
@@ -322,7 +322,8 @@ export class ClipboardManager {
         if (fs.existsSync(this.storagePath)) {
             try {
                 const data = await fs.promises.readFile(this.storagePath, 'utf-8');
-                this.history = JSON.parse(data);
+                const parsed: unknown = JSON.parse(data);
+                this.history = Array.isArray(parsed) ? parsed : [];
             } catch (err) {
                 console.error('Failed to parse clipboard history file:', err);
                 this.history = [];

--- a/src/ai/aiEngine.ts
+++ b/src/ai/aiEngine.ts
@@ -162,20 +162,22 @@ export class AIEngine {
                 }, async (progress) => {
                     this.loadingProgress = progress;
 
-                    await new Promise<void>((res, rej) => {
-                        const interval = setInterval(() => {
-                            if (this.status === 'ready') {
-                                clearInterval(interval);
-                                res();
-                            } else if (this.status === 'error') {
-                                clearInterval(interval);
-                                rej(new Error('Worker initialization failed'));
-                            }
-                        }, 200);
-                    });
-
-                    this.loadingProgress = null;
-                });
+                    try {
+                        await new Promise<void>((res, rej) => {
+                            const interval = setInterval(() => {
+                                if (this.status === 'ready') {
+                                    clearInterval(interval);
+                                    res();
+                                } else if (this.status === 'error') {
+                                    clearInterval(interval);
+                                    rej(new Error('Worker initialization failed'));
+                                }
+                            }, 200);
+                        });
+                    } finally {
+                        this.loadingProgress = null;
+                    }
+                }).then(undefined, () => { /* rejection handled by the outer promise */ });
 
                 checkStatus();
             });

--- a/src/ai/openAIClient.ts
+++ b/src/ai/openAIClient.ts
@@ -123,7 +123,7 @@ export class OpenAICompatibleClient {
      */
     async testConnection(): Promise<ConnectionTestResult> {
         try {
-            const reply = await this.chat([
+            await this.chat([
                 { role: 'user', content: 'Reply with "ok" only.' }
             ], 5);
 

--- a/src/core/PrivacyManager.ts
+++ b/src/core/PrivacyManager.ts
@@ -315,10 +315,10 @@ export class PrivacyManager {
     }
 
     private generateTokenId(): string {
-        return `tok_${Date.now()}_${Math.random().toString(36).substr(2, 6)}`;
+        return `tok_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
     }
 
     private generateId(): string {
-        return `dict_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        return `dict_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
     }
 }

--- a/src/core/PromptManager.ts
+++ b/src/core/PromptManager.ts
@@ -44,7 +44,12 @@ export class PromptManager {
         }
         try {
             const content = fs.readFileSync(this.promptsFilePath, 'utf-8');
-            const prompts: Prompt[] = JSON.parse(content);
+            const parsed: unknown = JSON.parse(content);
+            if (!Array.isArray(parsed)) {
+                this.createBackup();
+                return { prompts: [], version: 0 };
+            }
+            const prompts: Prompt[] = parsed;
             const version = PathUtils.getMtime(this.promptsFilePath);
 
             // Normalize/migrate each prompt

--- a/src/core/VersionManager.ts
+++ b/src/core/VersionManager.ts
@@ -286,7 +286,7 @@ export class VersionManager {
     }
 
     private generateVersionId(): string {
-        return `v${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        return `v${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
     }
 
     private pruneVersions(history: VersionHistory): void {

--- a/src/services/VersionHistoryService.ts
+++ b/src/services/VersionHistoryService.ts
@@ -54,7 +54,20 @@ export class VersionHistoryService {
             const historyPath = this.getHistoryPath(location);
             const uri = vscode.Uri.file(historyPath);
             const content = await vscode.workspace.fs.readFile(uri);
-            const history: VersionHistory = JSON.parse(content.toString());
+            const parsed: unknown = JSON.parse(content.toString());
+
+            if (!VersionHistoryService.isValidHistory(parsed)) {
+                console.error(`Invalid version history shape for ${promptId}, resetting to empty`);
+                const resetHistory: VersionHistory = {
+                    promptId,
+                    versions: [],
+                    currentVersionId: ''
+                };
+                this.cache.set(location.cacheKey, resetHistory);
+                return resetHistory;
+            }
+
+            const history = parsed;
             history.promptId = promptId;
 
             // Cache the loaded history
@@ -71,8 +84,31 @@ export class VersionHistoryService {
                 this.cache.set(location.cacheKey, emptyHistory);
                 return emptyHistory;
             }
+            if (error instanceof SyntaxError) {
+                // Corrupted JSON file — reset rather than crash the tree view/migration flow
+                console.error(`Failed to parse version history for ${promptId}, resetting to empty:`, error);
+                const resetHistory: VersionHistory = {
+                    promptId,
+                    versions: [],
+                    currentVersionId: ''
+                };
+                this.cache.set(location.cacheKey, resetHistory);
+                return resetHistory;
+            }
             throw error;
         }
+    }
+
+    /**
+     * Type guard to ensure parsed JSON matches the expected VersionHistory shape.
+     */
+    private static isValidHistory(value: unknown): value is VersionHistory {
+        return (
+            !!value &&
+            typeof value === 'object' &&
+            Array.isArray((value as VersionHistory).versions) &&
+            typeof (value as VersionHistory).currentVersionId === 'string'
+        );
     }
 
     /**

--- a/src/test/unit/clipboardManager.test.ts
+++ b/src/test/unit/clipboardManager.test.ts
@@ -125,3 +125,42 @@ describe('ClipboardManager.checkClipboard', () => {
         await expect(manager.checkClipboard('external', true)).rejects.toThrow('Permission denied');
     });
 });
+
+describe('ClipboardManager.loadHistory', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(realOs.tmpdir(), 'cm-loadhistory-test-'));
+        homedirMock.mockReturnValue(tmpDir);
+        readText.mockReset().mockResolvedValue('');
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        jest.clearAllMocks();
+    });
+
+    it('resets history to [] when clipboard-history.json contains non-array JSON', async () => {
+        const storageDir = path.join(tmpDir, '.quickprompt');
+        fs.mkdirSync(storageDir, { recursive: true });
+        fs.writeFileSync(path.join(storageDir, 'clipboard-history.json'), '{"not":"an-array"}', 'utf-8');
+
+        const manager = new ClipboardManager(makeContext());
+        await flushMicrotasks();
+
+        expect(manager.getHistory()).toEqual([]);
+        manager.dispose();
+    });
+
+    it('resets history to [] when clipboard-history.json contains null', async () => {
+        const storageDir = path.join(tmpDir, '.quickprompt');
+        fs.mkdirSync(storageDir, { recursive: true });
+        fs.writeFileSync(path.join(storageDir, 'clipboard-history.json'), 'null', 'utf-8');
+
+        const manager = new ClipboardManager(makeContext());
+        await flushMicrotasks();
+
+        expect(manager.getHistory()).toEqual([]);
+        manager.dispose();
+    });
+});

--- a/src/test/unit/promptManager.test.ts
+++ b/src/test/unit/promptManager.test.ts
@@ -60,6 +60,19 @@ describe('PromptManager', () => {
             expect(backups.length).toBeGreaterThan(0);
         });
 
+        it('returns empty list and creates backup when JSON is valid but not an array', () => {
+            const promptsPath = path.join(tmpDir, '.vscode', 'prompts.json');
+            for (const invalidJson of ['{"id":"001"}', 'null', '"string"', '42']) {
+                fs.writeFileSync(promptsPath, invalidJson, 'utf-8');
+                manager.clearCache();
+                const { prompts } = manager.loadPrompts();
+                expect(prompts).toEqual([]);
+            }
+            const backups = fs.readdirSync(path.join(tmpDir, '.vscode'))
+                .filter(f => f.includes('.backup.'));
+            expect(backups.length).toBeGreaterThan(0);
+        });
+
         it('normalizes missing fields with defaults', () => {
             const raw = [{ id: '001', title: 'X', content: 'Y' }];
             writePrompts(tmpDir, raw as Prompt[]);

--- a/src/test/unit/versionHistoryService.test.ts
+++ b/src/test/unit/versionHistoryService.test.ts
@@ -1,0 +1,60 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+import { VersionHistoryService } from '../../services/VersionHistoryService';
+
+describe('VersionHistoryService', () => {
+    let tmpDir: string;
+    let historyDir: string;
+    let service: VersionHistoryService;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vhs-test-'));
+        (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file(tmpDir), name: 'test' }];
+        historyDir = path.join(tmpDir, '.vscode', '.quickprompt', 'history');
+        service = new VersionHistoryService(new (vscode as any).ExtensionContext());
+    });
+
+    afterEach(() => {
+        (vscode.workspace as any).workspaceFolders = undefined;
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('loadHistory', () => {
+        it('returns empty history when the file does not exist', async () => {
+            const history = await service.loadHistory('abc');
+            expect(history).toEqual({ promptId: 'abc', versions: [], currentVersionId: '' });
+        });
+
+        it('loads valid persisted history', async () => {
+            fs.mkdirSync(historyDir, { recursive: true });
+            const stored = {
+                promptId: 'abc',
+                versions: [{ versionId: 'v1', content: 'hi', timestamp: 1, changeType: 'create' }],
+                currentVersionId: 'v1'
+            };
+            fs.writeFileSync(path.join(historyDir, 'abc.history.json'), JSON.stringify(stored), 'utf-8');
+
+            const history = await service.loadHistory('abc');
+            expect(history.versions).toHaveLength(1);
+            expect(history.currentVersionId).toBe('v1');
+        });
+
+        it('resets to empty history when the file contains corrupted JSON', async () => {
+            fs.mkdirSync(historyDir, { recursive: true });
+            fs.writeFileSync(path.join(historyDir, 'abc.history.json'), '{not valid json', 'utf-8');
+
+            const history = await service.loadHistory('abc');
+            expect(history).toEqual({ promptId: 'abc', versions: [], currentVersionId: '' });
+        });
+
+        it('resets to empty history when the file contains JSON of the wrong shape', async () => {
+            fs.mkdirSync(historyDir, { recursive: true });
+            fs.writeFileSync(path.join(historyDir, 'abc.history.json'), JSON.stringify([1, 2, 3]), 'utf-8');
+
+            const history = await service.loadHistory('abc');
+            expect(history).toEqual({ promptId: 'abc', versions: [], currentVersionId: '' });
+        });
+    });
+});


### PR DESCRIPTION
## 變更摘要

整合 #33、#34、#35、#39、#40、#41 的實際修正，準備 Quick Prompt 0.5.7 patch release。

- 強化 clipboard history、prompts.json、version history 面對 malformed JSON 或非預期 shape 時的 fallback。
- 修正 local Qwen 初始化失敗時的 progress cleanup 與 withProgress rejection handling。
- 移除 deprecated substr 用法與 unused reply assignment。
- 補 0.5.7 changelog、package.json、package-lock.json，並更新 bundled quickprompt skill script。

## 驗證

- git diff --check
- git diff --cached --check
- npx tsc -p ./
- npm test
- npx jest src/test/unit --runInBand --modulePathIgnorePatterns .claude --testPathIgnorePatterns .claude
- npm run vscode:prepublish
- 本地手測：使用者回報看起來正常

## Release note

這是 release/integration PR，請加 release-ready label 觸發版本檢查。