### PR TITLE
[Routine - QP] fix: streamline quick create workspace routing

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -483,36 +483,11 @@ async function handleInsertPrompt(item: PromptItem, promptProvider: PromptProvid
 }
 
 /**
- * Helper to pick target workspace in multi-root setup
+ * Resolve the target workspace for high-frequency create flows without
+ * interrupting the user with a workspace picker.
  */
-async function pickWorkspace(promptProvider: PromptProvider): Promise<string | undefined> {
-    const configs = promptProvider.getWorkspaceConfigs();
-    if (!configs || configs.length <= 1) {
-        return configs?.[0]?.key;
-    }
-
-    const activeEditor = vscode.window.activeTextEditor;
-    if (activeEditor) {
-        const folder = vscode.workspace.getWorkspaceFolder(activeEditor.document.uri);
-        if (folder) {
-            const matched = configs.find((c: any) => c.uri.toString() === folder.uri.toString());
-            if (matched) {
-                return matched.key;
-            }
-        }
-    }
-
-    const items: (vscode.QuickPickItem & { workspaceKey: string })[] = configs.map((c) => ({
-        label: c.name,
-        description: c.uri.fsPath,
-        workspaceKey: c.key
-    }));
-
-    const selected = await vscode.window.showQuickPick(items, {
-        placeHolder: '選擇要將 Prompt 儲存至哪一個工作區？'
-    });
-
-    return selected?.workspaceKey;
+function resolveQuickCreateWorkspace(promptProvider: PromptProvider): string | undefined {
+    return promptProvider.getQuickCreateWorkspaceKey();
 }
 
 /**
@@ -523,8 +498,9 @@ async function handleAddPrompt(
     promptProvider: PromptProvider,
     fileSystemProvider: PromptFileSystemProvider
 ): Promise<void> {
-    const targetWorkspace = await pickWorkspace(promptProvider);
+    const targetWorkspace = resolveQuickCreateWorkspace(promptProvider);
     if (!targetWorkspace) {
+        vscode.window.showWarningMessage('Quick Prompt: No workspace available to save the prompt.');
         return;
     }
 
@@ -555,11 +531,6 @@ async function handleAddPromptWithTitle(
     promptProvider: PromptProvider,
     titleGenService: TitleGenerationService
 ): Promise<void> {
-    const targetWorkspace = await pickWorkspace(promptProvider);
-    if (!targetWorkspace) {
-        return;
-    }
-
     const title = await vscode.window.showInputBox({
         prompt: I18n.getMessage('input.addPromptWithTitleTitlePrompt'),
         placeHolder: I18n.getMessage('input.addPromptTitlePlaceholder'),
@@ -590,6 +561,12 @@ async function handleAddPromptWithTitle(
         return;
     }
 
+    const targetWorkspace = resolveQuickCreateWorkspace(promptProvider);
+    if (!targetWorkspace) {
+        vscode.window.showWarningMessage('Quick Prompt: No workspace available to save the prompt.');
+        return;
+    }
+
     await promptProvider.addPromptWithOption(title.trim(), content.trim(), false, 'user', targetWorkspace);
 }
 
@@ -614,8 +591,9 @@ async function handleSilentAdd(
         return;
     }
 
-    const targetWorkspace = await pickWorkspace(promptProvider);
+    const targetWorkspace = resolveQuickCreateWorkspace(promptProvider);
     if (!targetWorkspace) {
+        vscode.window.showWarningMessage('Quick Prompt: No workspace available to save the prompt.');
         return;
     }
 
@@ -749,8 +727,9 @@ async function handlePinClipboardItem(
 ): Promise<void> {
     if (!item || !item.item) return;
 
-    const targetWorkspace = await pickWorkspace(promptProvider);
+    const targetWorkspace = resolveQuickCreateWorkspace(promptProvider);
     if (!targetWorkspace) {
+        vscode.window.showWarningMessage('Quick Prompt: No workspace available to save the prompt.');
         return;
     }
 

--- a/src/promptProvider.ts
+++ b/src/promptProvider.ts
@@ -29,6 +29,7 @@ export type PromptTreeItem = PromptItem | VersionItem;
 
 export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
     private static readonly scopeStateKey = 'quickPrompt.activeWorkspaceScope';
+    private static readonly lastCreateWorkspaceStateKey = 'quickPrompt.lastCreateWorkspaceKey';
     private _onDidChangeTreeData: vscode.EventEmitter<PromptTreeItem | undefined | null | void> = new vscode.EventEmitter<PromptTreeItem | undefined | null | void>();
     readonly onDidChangeTreeData: vscode.Event<PromptTreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
 
@@ -450,6 +451,41 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
         return this.workspaceConfigs[0]?.key || 'global';
     }
 
+    public getQuickCreateWorkspaceKey(): string | undefined {
+        if (!this.workspaceConfigs || this.workspaceConfigs.length === 0) {
+            return undefined;
+        }
+
+        if (this.workspaceConfigs.length === 1) {
+            return this.workspaceConfigs[0].key;
+        }
+
+        const activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor) {
+            const folder = vscode.workspace.getWorkspaceFolder(activeEditor.document.uri);
+            if (folder) {
+                const matched = this.workspaceConfigs.find(c => c.uri.toString() === folder.uri.toString());
+                if (matched) {
+                    return matched.key;
+                }
+            }
+        }
+
+        const activeScopeKeys = this.getActiveWorkspaceScopeKeys();
+        if (activeScopeKeys.length === 1 && this.getWorkspaceConfig(activeScopeKeys[0])) {
+            return activeScopeKeys[0];
+        }
+
+        const lastCreateWorkspaceKey = this.context.workspaceState.get<string | undefined>(
+            PromptProvider.lastCreateWorkspaceStateKey
+        );
+        if (lastCreateWorkspaceKey && this.getWorkspaceConfig(lastCreateWorkspaceKey)) {
+            return lastCreateWorkspaceKey;
+        }
+
+        return this.workspaceConfigs[0].key;
+    }
+
     async addPrompt(title: string, content: string, titleSource?: 'user' | 'ai') {
         await this.addPromptWithOption(title, content, false, titleSource);
     }
@@ -501,6 +537,7 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
         };
         this.prompts.push(newPrompt);
         await this.savePrompts();
+        await this.context.workspaceState.update(PromptProvider.lastCreateWorkspaceStateKey, workspaceKey);
         this._onDidChangeTreeData.fire();
 
         if (!silent) {

--- a/src/test/unit/promptProviderMultiroot.test.ts
+++ b/src/test/unit/promptProviderMultiroot.test.ts
@@ -24,7 +24,17 @@ describe('PromptProvider multi-root routing', () => {
     }
 
     function makeContext(): vscode.ExtensionContext {
-        return new (vscode as any).ExtensionContext();
+        const context = new (vscode as any).ExtensionContext();
+        const state = new Map<string, unknown>();
+        context.workspaceState = {
+            get: jest.fn((key: string, defaultValue?: unknown) => state.has(key) ? state.get(key) : defaultValue),
+            update: jest.fn((key: string, value: unknown) => {
+                state.set(key, value);
+                return Promise.resolve();
+            }),
+            keys: jest.fn(() => Array.from(state.keys()))
+        };
+        return context;
     }
 
     beforeEach(() => {
@@ -180,5 +190,55 @@ describe('PromptProvider multi-root routing', () => {
         expect((children[0] as PromptItem).prompt.title).toBe('Prompt B');
         expect(provider.getScopeDescription()).toBe('ProjectB');
         expect(provider.shouldShowWorkspaceLabels()).toBe(false);
+    });
+
+    it('uses the active editor workspace for quick-create target', async () => {
+        writePrompts(tmpDir1, []);
+        writePrompts(tmpDir2, []);
+
+        (vscode.window as any).activeTextEditor = {
+            document: { uri: vscode.Uri.file(path.join(tmpDir2, 'source.ts')) }
+        };
+
+        const context = makeContext();
+        const provider = new PromptProvider(context, new VersionHistoryService(context));
+        await provider.refresh();
+
+        const projectBKey = provider.getWorkspaceConfigs().find(config => config.name === 'ProjectB')?.key;
+        expect(projectBKey).toBeDefined();
+        expect(provider.getQuickCreateWorkspaceKey()).toBe(projectBKey);
+    });
+
+    it('uses a single selected scope for quick-create target when there is no active editor workspace', async () => {
+        writePrompts(tmpDir1, []);
+        writePrompts(tmpDir2, []);
+
+        const context = makeContext();
+        const provider = new PromptProvider(context, new VersionHistoryService(context));
+        await provider.refresh();
+
+        const projectBKey = provider.getWorkspaceConfigs().find(config => config.name === 'ProjectB')?.key;
+        expect(projectBKey).toBeDefined();
+
+        await provider.setActiveWorkspaceScope([projectBKey!]);
+
+        expect(provider.getQuickCreateWorkspaceKey()).toBe(projectBKey);
+    });
+
+    it('remembers the last create workspace when scope shows all workspaces', async () => {
+        writePrompts(tmpDir1, []);
+        writePrompts(tmpDir2, []);
+
+        const context = makeContext();
+        const provider = new PromptProvider(context, new VersionHistoryService(context));
+        await provider.refresh();
+
+        const projectBKey = provider.getWorkspaceConfigs().find(config => config.name === 'ProjectB')?.key;
+        expect(projectBKey).toBeDefined();
+
+        await provider.addPromptWithOption('Prompt B', 'B', true, 'user', projectBKey);
+        await provider.setActiveWorkspaceScope([]);
+
+        expect(provider.getQuickCreateWorkspaceKey()).toBe(projectBKey);
     });
 });


### PR DESCRIPTION
## 變更摘要
- 讓 Add Prompt / Add Prompt With Title / Silent Add / Pin Clipboard Item 在 multi-root 下不再先跳 workspace picker。
- 新增 quick-create target fallback：active editor workspace -> single selected scope -> last used create workspace -> default workspace。
- 成功建立 prompt 後記錄 last-used create workspace，讓 clipboard pin / no active editor 場景維持快速。
- Add Prompt With Title 改成先輸入 title/content，再解析保存目標，避免 workspace 成為第一步。

## 驗證
- `git diff --check`
- `npx tsc -p ./`
- `npx jest src/test/unit/promptProviderMultiroot.test.ts --runInBand --modulePathIgnorePatterns .claude --testPathIgnorePatterns .claude`
- `npx jest src/test/unit --runInBand --modulePathIgnorePatterns ".claude|.vscode-test" --testPathIgnorePatterns ".claude|.vscode-test"`
- `npm run vscode:prepublish`

## 備註
- 這是 routine UX 修正，不包含 version bump / CHANGELOG / `release-ready`。