### PR TITLE
[Routine - QP] test: ignore local Claude worktrees in Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,8 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     testMatch: ['**/src/test/**/*.test.ts'],
-    testPathIgnorePatterns: ['/node_modules/', '/src/test/ui/', '/.vscode-test/'],
-    modulePathIgnorePatterns: ['<rootDir>/.vscode-test/', '<rootDir>/dist/'],
+    testPathIgnorePatterns: ['/node_modules/', '/src/test/ui/', '/.vscode-test/', '/.claude/'],
+    modulePathIgnorePatterns: ['<rootDir>/.vscode-test/', '<rootDir>/.claude/', '<rootDir>/dist/'],
     transform: {
         '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
     },


### PR DESCRIPTION
## 變更摘要
- 讓 Jest 忽略本機 `.claude/**` 路徑，避免 local worktree 裡的 `src/test/**/*.test.ts` 被 `npm test` 一起掃進來。
- 同步把 `.claude` 加到 `modulePathIgnorePatterns`，避免 module crawler 解析殘留 worktree 的 mock/module。

## 背景
本機曾殘留多個 `.claude/worktrees/*`，其中包含 `src/test/unit/*.test.ts`。目前 `jest.config.js` 的 `testMatch` 是 `**/src/test/**/*.test.ts`，因此 open 或 stale worktree 會污染 `npm test` 的測試集合。

## 已處理的本地清理
- 已移除 6 個 closed routine PR 對應的乾淨 `.claude/worktrees/*`。
- 已移除乾淨且 detached 的 `C:/tmp/quickprompt-pr20` worktree。
- 保留 #44 對應的 open worktree：`.claude/worktrees/admiring-yonath-272b3f`。

## 驗證
- `npx jest --listTests --runInBand | Select-String -Pattern "\.claude\\worktrees|\.claude/worktrees" | Measure-Object` -> `Count: 0`
- `npm test` -> 7 suites / 107 tests passed
- `npx tsc -p ./`
- `git diff --check`

## 備註
- 這是 routine test hygiene PR，不包含 version bump / CHANGELOG / `release-ready`。