### PR TITLE
[Routine - QP] refactor: replace deprecated String.substr() in VersionHistoryService

### DIFF
--- a/src/services/VersionHistoryService.ts
+++ b/src/services/VersionHistoryService.ts
@@ -428,6 +428,6 @@ export class VersionHistoryService {
      * Generate a unique version ID
      */
     private generateVersionId(): string {
-        return `v${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        return `v${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
     }
 }


### PR DESCRIPTION
## Pre-flight Check

Open PRs and active branches checked before creating this PR:

| PR / Branch | Files Touched | Conflict? |
|---|---|---|
| #45 `chore/ignore-claude-worktrees-jest` | `jest.config.js` | None |
| #44 `routine/qp-fix-path-traversal-prefix-260702` | `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts` | None |
| #43 `fix/quick-create-workspace-ux` | `src/commands.ts`, `src/promptProvider.ts`, `src/test/unit/promptProviderMultiroot.test.ts` | None |

This PR only modifies `src/services/VersionHistoryService.ts`, which none of the above touch.

Also checked: closed-but-unmerged routine branches (`routine/qp-fix-substr-deprecation-260625` / PR #33, `routine/qp-fix-non-array-json-260627` / PR #35, `routine/qp-fix-corrupted-clipboard-json-260626` / PR #34, `routine/qp-fix-ai-progress-cleanup-260629` / PR #39, `routine/qp-fix-unused-reply-var-260630` / PR #40, `routine/qp-fix-version-history-corrupt-json-260701` / PR #41). Their code changes are already present on `master` (this repo squash-merges, so PRs can show `CLOSED`/`mergedAt: null` even though the diff landed — verified by grepping master for each fix, per prior guidance on this repo).

The one exception: PR #33 explicitly **excluded** `src/services/VersionHistoryService.ts:395` (now line 431) from its `.substr()` → `.substring()` cleanup, because at the time it conflicted with the then-open PR #32 (`chore/issue-25-skill-install-scope`). PR #32 has since merged (2026-06-26), so that conflict no longer exists, and this call is the only remaining `.substr()` usage in `src/` and `mcp-server/src/` (verified via grep). This PR completes that deferred cleanup.

## Changes

- `src/services/VersionHistoryService.ts:431` — `Math.random().toString(36).substr(2, 9)` → `Math.random().toString(36).substring(2, 11)` (behaviorally identical: `substr(start, length)` ≡ `substring(start, start + length)` for non-negative indices).

Confirmed this PR does not modify any MCP tool schema (`mcp-server/src/tools/` untouched), does not add/remove/update dependencies, and does not touch `package.json`, `package-lock.json`, or `CHANGELOG.md`.

## Safety Verification

Commands run locally, in order:

```
npx tsc -p ./
```
✅ No output, no errors.

```
npm run test
```
✅ `Test Suites: 7 passed, 7 total`, `Tests: 107 passed, 107 total`.

No `lint` or `format:check` script is defined in `package.json` for this project (consistent with prior routine PRs), so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If GitHub Actions fails only because of the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)