### PR TITLE
[Routine - QP] fix: guard against non-array JSON in MCP clipboard history load

### DIFF
--- a/mcp-server/src/tools/clipboardTools.ts
+++ b/mcp-server/src/tools/clipboardTools.ts
@@ -24,7 +24,8 @@ export class ClipboardTools {
     if (fs.existsSync(storagePath)) {
       try {
         const data = fs.readFileSync(storagePath, 'utf-8');
-        return JSON.parse(data) as ClipboardHistoryItem[];
+        const parsed: unknown = JSON.parse(data);
+        return Array.isArray(parsed) ? (parsed as ClipboardHistoryItem[]) : [];
       } catch (err) {
         throw new Error(`Failed to read clipboard history: ${err}`);
       }


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs / active routine branches checked before starting:

- #46 `routine/qp-fix-versionhistory-substr-260703` — touches `src/services/VersionHistoryService.ts`
- #45 `chore/ignore-claude-worktrees-jest` — touches `jest.config.js`
- #44 `routine/qp-fix-path-traversal-prefix-260702` — touches `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts`
- #43 `fix/quick-create-workspace-ux` — touches `src/commands.ts`, `src/promptProvider.ts`, `src/test/unit/promptProviderMultiroot.test.ts`

Also reviewed several closed-but-not-merged `routine/qp-fix-*` branches (e.g. `qp-fix-corrupted-clipboard-json-260626` / PR #34) to understand prior work in this area — that one guarded `src/ClipboardManager.ts` against non-array JSON, but the equivalent gap in the MCP server's clipboard tool (`mcp-server/src/tools/clipboardTools.ts`) was never fixed and that PR is closed.

This PR only touches `mcp-server/src/tools/clipboardTools.ts`, which is not modified by any of the above — no overlap.

## 2. Changes

`ClipboardTools.loadHistory()` cast `JSON.parse(data)` straight to `ClipboardHistoryItem[]` with no shape check. If `~/.quickprompt/clipboard-history.json` is valid JSON but not an array (e.g. corrupted to `{}` or `null`), the object masquerades as an array downstream in `getClipboardItem()`: `history.length` becomes `undefined`, bounds checks against `NaN` always pass, and the code falls through to `history[targetIndex].content`, throwing an unhandled-shape `TypeError` that surfaces as a raw internal error message to the MCP client.

Fix: parse into `unknown` first and fall back to `[]` when the result isn't an array, matching the existing guard already used in `src/ClipboardManager.ts`.

- Does not modify any tool schema, name, or parameters in `mcp-server/src/tools/`.
- Does not add/remove/update any dependency.
- Does not touch `package.json`, `package-lock.json`, or `CHANGELOG.md`.

## 3. Safety Verification

Commands run locally, all passed:

- `npx tsc -p ./` — no errors
- `npm run test` (jest --runInBand) — 7 suites / 107 tests passed

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repo's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)