### PR TITLE
[Routine - QP] fix: guard VersionManager against malformed history JSON shape

### DIFF
--- a/src/core/VersionManager.ts
+++ b/src/core/VersionManager.ts
@@ -59,7 +59,11 @@ export class VersionManager {
 
         try {
             const content = fs.readFileSync(historyPath, 'utf-8');
-            const history: VersionHistory = JSON.parse(content);
+            const parsed: unknown = JSON.parse(content);
+            if (!VersionManager.isValidHistory(parsed)) {
+                throw new Error(`Malformed version history shape for ${promptId}`);
+            }
+            const history: VersionHistory = parsed;
             this.cache.set(promptId, { history, mtimeMs: currentMtime });
             return JSON.parse(JSON.stringify(history));
         } catch {
@@ -70,6 +74,20 @@ export class VersionManager {
             };
             return emptyHistory;
         }
+    }
+
+    /**
+     * Type guard ensuring parsed JSON matches the expected VersionHistory shape,
+     * so a corrupted or unexpectedly-shaped history.json falls back to empty
+     * history instead of throwing later (e.g. `history.versions.find` on undefined).
+     */
+    private static isValidHistory(value: unknown): value is VersionHistory {
+        return (
+            !!value &&
+            typeof value === 'object' &&
+            Array.isArray((value as VersionHistory).versions) &&
+            typeof (value as VersionHistory).currentVersionId === 'string'
+        );
     }
 
     /**

--- a/src/test/unit/versionManager.test.ts
+++ b/src/test/unit/versionManager.test.ts
@@ -40,6 +40,24 @@ describe('VersionManager', () => {
         it('throws for invalid promptId with path traversal', () => {
             expect(() => manager.loadHistory('../evil')).toThrow('Invalid promptId');
         });
+
+        it('resets to empty history when the file contains corrupted JSON', () => {
+            const historyDir = path.join(tmpDir, '.vscode', '.quickprompt', 'history');
+            fs.mkdirSync(historyDir, { recursive: true });
+            fs.writeFileSync(path.join(historyDir, '001.history.json'), '{not valid json', 'utf-8');
+
+            const history = manager.loadHistory('001');
+            expect(history).toEqual({ promptId: '001', versions: [], currentVersionId: '' });
+        });
+
+        it('resets to empty history when the file contains JSON of the wrong shape', () => {
+            const historyDir = path.join(tmpDir, '.vscode', '.quickprompt', 'history');
+            fs.mkdirSync(historyDir, { recursive: true });
+            fs.writeFileSync(path.join(historyDir, '001.history.json'), JSON.stringify([1, 2, 3]), 'utf-8');
+
+            const history = manager.loadHistory('001');
+            expect(history).toEqual({ promptId: '001', versions: [], currentVersionId: '' });
+        });
     });
 
     // ── createVersion ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Pre-flight Check

Open PRs / active branches checked before selecting this target:

- #47 `routine/qp-fix-mcp-clipboard-non-array-260706` — touches `mcp-server/src/tools/clipboardTools.ts`
- #46 `routine/qp-fix-versionhistory-substr-260703` — touches `src/services/VersionHistoryService.ts`
- #45 `chore/ignore-claude-worktrees-jest` — touches `jest.config.js`
- #44 `routine/qp-fix-path-traversal-prefix-260702` — touches `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts`
- #43 `fix/quick-create-workspace-ux` — touches `src/commands.ts`, `src/promptProvider.ts`, `src/test/unit/promptProviderMultiroot.test.ts`

This PR only touches `src/core/VersionManager.ts` and `src/test/unit/versionManager.test.ts`, which none of the above PRs modify, so there is no overlap.

## Changes

`VersionManager.loadHistory` (the pure Node.js core version manager, distinct from `VersionHistoryService.ts` which #46 is fixing) parses `*.history.json` with a bare `JSON.parse` inside a try/catch. The catch only handles `JSON.parse` throwing (e.g. corrupted JSON) — it does **not** catch the case where parsing succeeds but produces the wrong shape (e.g. the file contains `[1,2,3]` or `{}` instead of `{ promptId, versions, currentVersionId }`). In that case `history.versions` is `undefined`, and the very next line calling `.find(...)` elsewhere (`getCurrentVersion`, `applyVersion`, `createVersion`, etc.) throws a raw `TypeError` instead of falling back gracefully.

This mirrors the fix already merged for the sibling file `VersionHistoryService.ts` (commit `20b6a09`, "guard VersionHistoryService against corrupted/malformed history JSON") — same bug pattern, same fallback strategy (reset to empty history), applied to the not-yet-patched `VersionManager.ts`.

- Added a `VersionManager.isValidHistory` type guard (same shape check as `VersionHistoryService.isValidHistory`).
- `loadHistory` now throws internally (caught by the existing catch block) when the parsed JSON doesn't match the expected shape, resetting to an empty history instead of letting a malformed shape propagate.
- Added two unit tests mirroring the existing `VersionHistoryService` corrupted-JSON tests: corrupted JSON text, and valid-but-wrong-shape JSON (an array).

Confirms this PR does **not** modify any MCP tool schema/names/parameters in `mcp-server/src/tools/`, and does not add/remove/update any dependencies.

## Safety Verification

Commands run locally, all passed:

- `npx tsc -p ./` — no errors
- `npm run test:coverage` (project's Jest command) — 7 test suites, 109 tests, all passed (includes the 2 new tests plus all pre-existing suites)

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If GitHub Actions fails only due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.