### PR TITLE
[Routine - QP] fix: avoid logging full backup file path in PromptManager

### DIFF
--- a/src/core/PromptManager.ts
+++ b/src/core/PromptManager.ts
@@ -277,7 +277,7 @@ export class PromptManager {
             if (fs.existsSync(this.promptsFilePath)) {
                 const backupPath = `${this.promptsFilePath}.backup.${Date.now()}`;
                 fs.copyFileSync(this.promptsFilePath, backupPath);
-                console.error(`[PromptManager] Created backup: ${backupPath}`);
+                console.error(`[PromptManager] Created backup: ${path.basename(backupPath)}`);
             }
         } catch { /* ignore backup errors */ }
     }


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs / active branches checked (as of 2026-07-08):
- #48 `routine/qp-fix-versionmanager-malformed-json-260707` — touches `src/core/VersionManager.ts`, `src/test/unit/versionManager.test.ts`
- #47 `routine/qp-fix-mcp-clipboard-non-array-260706` — touches `mcp-server/src/tools/clipboardTools.ts`
- #46 `routine/qp-fix-versionhistory-substr-260703` — touches `src/services/VersionHistoryService.ts`
- #45 `chore/ignore-claude-worktrees-jest` — touches `jest.config.js`
- #44 `routine/qp-fix-path-traversal-prefix-260702` — touches `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts`
- #43 `fix/quick-create-workspace-ux` — touches `src/commands.ts`, `src/promptProvider.ts`, `src/test/unit/promptProviderMultiroot.test.ts`

This PR only touches `src/core/PromptManager.ts` (a single log line in `createBackup()`), which does not overlap with any file above. It also does not overlap topically with recently closed duplicate-attempt PRs (#33–35, #39–41), which covered `substr` deprecation, non-array JSON guards, and corrupted-JSON handling — this change is purely about log output, not parsing/validation logic.

## 2. Changes

`PromptManager.createBackup()` previously logged the **full absolute path** of the corruption backup file (`console.error('[PromptManager] Created backup: ' + backupPath)`), which embeds the user's workspace directory (and often their OS username via the home directory). This PR logs only `path.basename(backupPath)` instead, keeping the log useful (still shows the backup filename/timestamp) without leaking the local filesystem layout.

- No MCP tool schemas, names, or parameters were touched (`mcp-server/src/tools/` untouched).
- No dependencies added/removed; `package.json` / `package-lock.json` untouched.
- `CHANGELOG.md` untouched (per routine PR policy).

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test:coverage` — 7 test suites, 107 tests, all passed

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.