### PR TITLE
[Routine - QP] fix: restore all occurrences when unmasking repeated privacy tokens

### DIFF
--- a/src/core/PrivacyManager.ts
+++ b/src/core/PrivacyManager.ts
@@ -161,7 +161,8 @@ export class PrivacyManager {
         let result = maskedText;
         for (const [maskedValue, token] of this.tokenStore) {
             if (token.reversible && result.includes(maskedValue)) {
-                result = result.replace(maskedValue, token.originalValue);
+                // split/join replaces every occurrence — String.replace(string) only replaces the first
+                result = result.split(maskedValue).join(token.originalValue);
             }
         }
         return result;

--- a/src/test/unit/privacyManager.test.ts
+++ b/src/test/unit/privacyManager.test.ts
@@ -1,0 +1,44 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { PrivacyManager } from '../../core/PrivacyManager';
+
+describe('PrivacyManager', () => {
+    let tmpDir: string;
+    let manager: PrivacyManager;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-privacy-test-'));
+        manager = new PrivacyManager(tmpDir);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    // ── unmaskText ────────────────────────────────────────────────────────────
+
+    describe('unmaskText', () => {
+        it('restores every occurrence when the same value is masked multiple times', () => {
+            manager.addDictionaryEntry({
+                pattern: 'ACME',
+                isRegex: false,
+                label: '[COMPANY]',
+                enabled: true,
+            });
+
+            const original = 'ACME Corp partners with ACME Inc on this project.';
+            const { maskedText } = manager.maskText(original);
+
+            expect(maskedText).toBe('[COMPANY] Corp partners with [COMPANY] Inc on this project.');
+            expect(manager.unmaskText(maskedText)).toBe(original);
+        });
+
+        it('restores multiple distinct masked values', () => {
+            const original = 'Contact a@example.com or b@example.com for details.';
+            const { maskedText } = manager.maskText(original);
+
+            expect(manager.unmaskText(maskedText)).toBe(original);
+        });
+    });
+});


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs / active branches checked (Phase 1):

| # | Branch | Files touched |
|---|--------|---------------|
| 49 | `routine/qp-fix-backup-log-path-leak-260708` | `src/core/PromptManager.ts` |
| 48 | `routine/qp-fix-versionmanager-malformed-json-260707` | `src/core/VersionManager.ts`, `src/test/unit/versionManager.test.ts` |
| 47 | `routine/qp-fix-mcp-clipboard-non-array-260706` | `mcp-server/src/tools/clipboardTools.ts` |
| 46 | `routine/qp-fix-versionhistory-substr-260703` | `src/services/VersionHistoryService.ts` |
| 45 | `chore/ignore-claude-worktrees-jest` | `jest.config.js` |
| 44 | `routine/qp-fix-path-traversal-prefix-260702` | `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts` |
| 43 | `fix/quick-create-workspace-ux` | `src/commands.ts`, `src/promptProvider.ts`, `src/test/unit/promptProviderMultiroot.test.ts` |

Also reviewed `origin/copilot/support-local-ml-pii-detection` (no open PR) — it's a large, divergent WIP branch touching most of the codebase (net -17k lines), but does not touch `src/core/PrivacyManager.ts`.

This PR only touches `src/core/PrivacyManager.ts` and adds a new test file `src/test/unit/privacyManager.test.ts`, so there is no overlap with any of the above.

## 2. Changes

`PrivacyManager.unmaskText()` restored masked tokens using `String.prototype.replace(maskedValue, ...)` with a plain string argument, which only replaces the **first** match. Dictionary-based masking assigns the same fixed label (`entry.label`) to every occurrence of a matched value, so any text where a dictionary-masked value appeared more than once was left partially masked after calling `unmaskText`.

Fix: replace all occurrences via `result.split(maskedValue).join(token.originalValue)` instead of a single `.replace()`.

Added `src/test/unit/privacyManager.test.ts` covering:
- a dictionary entry matching the same value twice in one string (repro for the bug)
- two distinct built-in pattern matches (regression guard)

This PR does **not** modify any MCP tool schema/name/parameters (`mcp-server/src/tools/` untouched), and does not add/remove/update any dependencies.

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (Jest) — 8/8 suites, 109/109 tests passed (including the 2 new tests)

No `lint` / `format:check` scripts exist in `package.json`, so they were not run.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.