### PR TITLE
[Routine - QP] fix: avoid logging full file paths in extension activation and AI worker startup

### DIFF
--- a/src/ai/aiEngine.ts
+++ b/src/ai/aiEngine.ts
@@ -117,7 +117,7 @@ export class AIEngine {
     private async initializeQwen(context: vscode.ExtensionContext): Promise<void> {
         try {
             const workerPath = path.join(__dirname, 'aiWorker.js');
-            console.log('[AIEngine] Spawning Qwen worker from:', workerPath);
+            console.log('[AIEngine] Spawning Qwen worker from:', path.basename(workerPath));
 
             this.worker = new Worker(workerPath);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { PromptProvider } from './promptProvider';
 import { ClipboardProvider } from './clipboardProvider';
 import { PromptFileSystemProvider } from './promptFileSystem';
@@ -34,7 +35,7 @@ async function deployMcpServer(context: vscode.ExtensionContext): Promise<string
         // Write to the stable path, overwriting any previous version
         await vscode.workspace.fs.writeFile(targetFile, sourceContent);
 
-        console.log(`[QuickPrompt] MCP server deployed to stable path: ${targetFile.fsPath}`);
+        console.log(`[QuickPrompt] MCP server deployed to stable path: ${path.basename(targetFile.fsPath)}`);
         return targetFile.fsPath.replace(/\\/g, '/');
     } catch (error) {
         // Deployment failure should not affect the extension's main functionality


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs and active routine branches checked before starting (via `gh pr list` and `git branch -r`):

| PR | Branch | Files touched |
|----|--------|----------------|
| #50 | routine/qp-fix-privacy-unmask-duplicate-260709 | `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts` |
| #49 | routine/qp-fix-backup-log-path-leak-260708 | `src/core/PromptManager.ts` |
| #48 | routine/qp-fix-versionmanager-malformed-json-260707 | `src/core/VersionManager.ts`, `src/test/unit/versionManager.test.ts` |
| #47 | routine/qp-fix-mcp-clipboard-non-array-260706 | `mcp-server/src/tools/clipboardTools.ts` |
| #46 | routine/qp-fix-versionhistory-substr-260703 | `src/services/VersionHistoryService.ts` |
| #45 | chore/ignore-claude-worktrees-jest | `jest.config.js` |
| #44 | routine/qp-fix-path-traversal-prefix-260702 | `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts` |
| #43 | fix/quick-create-workspace-ux | `src/commands.ts`, `src/promptProvider.ts`, `src/test/unit/promptProviderMultiroot.test.ts` |

This PR touches only `src/extension.ts` and `src/ai/aiEngine.ts`, neither of which overlaps with the files above.

## 2. Changes

`src/extension.ts` (`deployMcpServer`) and `src/ai/aiEngine.ts` (`initializeQwen`) logged the **full absolute filesystem path** (including the user's home directory) to the debug console via `console.log`:
- `[QuickPrompt] MCP server deployed to stable path: <full path>`
- `[AIEngine] Spawning Qwen worker from: <full path>`

Both now log only `path.basename(...)`, matching the same redaction pattern already applied to `PromptManager` backup logging in open PR #49 (`console.error(\`[PromptManager] Created backup: ${path.basename(backupPath)}\`)`).

- Does not modify any MCP tool schema in `mcp-server/src/tools/`.
- Does not add/remove/update any dependency.
- Does not modify `package.json`, `package-lock.json`, or `CHANGELOG.md`.

## 3. Safety Verification

Commands run locally, both passed:
- `npx tsc -p ./` — no errors.
- `npm run test` — 7 suites / 107 tests passed.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)