### PR TITLE
[Routine - QP] fix: correct prompt ID extraction in hover provider virtual URI parsing

### DIFF
--- a/src/promptHoverProvider.ts
+++ b/src/promptHoverProvider.ts
@@ -41,13 +41,14 @@ export class PromptHoverProvider implements vscode.HoverProvider {
             return null;
         }
 
-        // 從 URI 中提取 Prompt ID
-        const fileName = document.uri.path.split('/').pop();
-        if (!fileName) {
+        // 從 URI 中提取 Prompt ID（虛擬路徑格式為 /<workspaceKey>/<actualId>.md 或 /<actualId>.md）
+        const cleanPath = document.uri.path.replace(/\.md$/, '');
+        const parts = cleanPath.substring(1).split('/').map(decodeURIComponent);
+        if (parts.length === 0 || !parts[0]) {
             return null;
         }
 
-        const promptId = fileName.replace('.md', '');
+        const promptId = parts.length >= 2 ? `${parts[0]}:${parts[1]}` : parts[0];
         const prompt = this.prompts.get(promptId);
 
         if (!prompt) {


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs / active branches checked in Phase 1:

| PR | Title | Files touched |
|----|-------|----|
| #51 | avoid logging full file paths in extension activation / AI worker startup | `src/ai/aiEngine.ts`, `src/extension.ts` |
| #50 | restore all occurrences when unmasking repeated privacy tokens | `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts` |
| #49 | avoid logging full backup file path in PromptManager | `src/core/PromptManager.ts` |
| #48 | guard VersionManager against malformed history JSON shape | `src/core/VersionManager.ts`, `src/test/unit/versionManager.test.ts` |
| #47 | guard against non-array JSON in MCP clipboard history load | `mcp-server/src/tools/clipboardTools.ts` |
| #46 | replace deprecated String.substr() in VersionHistoryService | `src/services/VersionHistoryService.ts` |
| #45 | ignore local Claude worktrees in Jest | `jest.config.js` |
| #44 | close prefix-match bypass in PathUtils.validatePath | `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts` |

This PR touches only `src/promptHoverProvider.ts`, which is not modified by any open PR, and the bug is unrelated to any of the topics above (log path leaks, JSON shape guards, substr deprecation, path traversal, privacy-unmask duplicates, Jest config). No overlap.

## 2. Changes

`PromptHoverProvider.provideHover` extracted the prompt ID from the virtual `quickprompt:` URI by taking only the last path segment (`fileName.replace('.md', '')`). However:

- `PromptFileSystemProvider.getUriForPrompt` always builds URIs as `quickprompt:/<workspaceKey>/<actualId>.md`.
- `PromptProvider.getPrefixedPromptId` always keys prompts internally as `"<workspaceKey>:<actualId>"` (there is no unprefixed case).

So the hover provider's lookup key (`actualId`) never matched the map key (`"wsKey:actualId"`), meaning **hover tooltips for prompt virtual files never rendered, in any workspace configuration**.

The fix reconstructs the ID the same way `PromptFileSystemProvider.getPromptIdFromUri` already does elsewhere in the codebase — joining the workspace-key and actual-id URI segments with `:` — instead of only reading the last segment.

Confirms this PR does not modify any MCP tool schema (`mcp-server/src/tools/` untouched) and does not add/remove/update any dependency.

## 3. Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./          # no errors
npm run test           # Test Suites: 7 passed, 7 total / Tests: 110 passed, 110 total
```

No `lint` or `format:check` npm scripts exist in this repo, so they were skipped. No existing test references `PromptHoverProvider`, so nothing else was affected.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If GitHub Actions fails only due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.