### PR TITLE
[Routine - QP] fix: correct backslash regex in generated skill path display

### DIFF
--- a/src/mcp/SkillGenerator.ts
+++ b/src/mcp/SkillGenerator.ts
@@ -234,7 +234,7 @@ description: Manages reusable prompts with version history and privacy masking v
 ${this.getSkillContent(context, scriptRunPath)}`;
 
         fs.writeFileSync(mdPath, content, 'utf8');
-        const relativeSkillPath = path.relative(projectRoot, mdPath).replace(/\\\\/g, '/');
+        const relativeSkillPath = path.relative(projectRoot, mdPath).replace(/\\/g, '/');
         vscode.window.showInformationMessage(`QuickPrompt skill file generated: ${relativeSkillPath}`);
 
         const document = await vscode.workspace.openTextDocument(vscode.Uri.file(mdPath));


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs checked (via `gh pr list` + `gh pr diff --name-only`), none overlap with this change:

- #52 `src/promptHoverProvider.ts`
- #51 `src/ai/aiEngine.ts`, `src/extension.ts`
- #50 `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts`
- #49 `src/core/PromptManager.ts`
- #48 `src/core/VersionManager.ts`, `src/test/unit/versionManager.test.ts`
- #47 `mcp-server/src/tools/clipboardTools.ts`
- #46 `src/services/VersionHistoryService.ts`
- #45 `jest.config.js`
- #44 `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts`

This PR touches `src/mcp/SkillGenerator.ts` only, which none of the above PRs modify.

## 2. Changes

`SkillGenerator.generateAgentSkill()` builds the relative path to the freshly-generated `SKILL.md` for the "skill file generated" info message:

```ts
const relativeSkillPath = path.relative(projectRoot, mdPath).replace(/\\/g, '/');
```

`/\\/g` matches two consecutive backslashes, but `path.relative()` on Windows returns single-backslash-separated paths (e.g. `.claude\skills\quickprompt\SKILL.md`). The replace was therefore a silent no-op on Windows, and the info message shown to users displayed raw Windows-style paths instead of the intended forward-slash form used elsewhere in the codebase (e.g. `McpConfigPanel.ts` uses the correct `/\/g` single-backslash pattern for the same purpose).

Fix: drop the duplicated escaping so the regex actually matches single backslashes:

```ts
const relativeSkillPath = path.relative(projectRoot, mdPath).replace(/\/g, '/');
```

This does not change any MCP tool schema, name, or parameter, and does not touch `mcp-server/src/tools/`. No dependency changes.

## 3. Safety Verification

Commands run locally, both passed:

- `npx tsc -p ./` — no errors
- `npm run test` (Jest, `--runInBand`) — 7 suites / 110 tests passed

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.