### PR TITLE
[Routine - QP] fix: dispose window focus listener in ClipboardManager

### DIFF
--- a/src/ClipboardManager.ts
+++ b/src/ClipboardManager.ts
@@ -20,6 +20,7 @@ export class ClipboardManager {
     private historyLoaded: boolean = false;
     private readonly storagePath: string;
     private readonly configListener: vscode.Disposable;
+    private windowStateListener: vscode.Disposable | null = null;
 
     // Cached config — invalidated on onDidChangeConfiguration
     private cfg = {
@@ -120,7 +121,7 @@ export class ClipboardManager {
      * 視窗焦點監聽 - 當 VSCode 獲得焦點時檢查剪貼簿
      */
     private registerWindowFocusListener() {
-        vscode.window.onDidChangeWindowState((state) => {
+        this.windowStateListener = vscode.window.onDidChangeWindowState((state) => {
             this.isVSCodeActive = state.focused;
 
             if (state.focused) {
@@ -372,6 +373,7 @@ export class ClipboardManager {
     dispose() {
         this.stopPolling();
         this.configListener.dispose();
+        this.windowStateListener?.dispose();
         this._onHistoryChanged.dispose();
     }
 }

--- a/src/test/unit/clipboardManager.test.ts
+++ b/src/test/unit/clipboardManager.test.ts
@@ -164,3 +164,30 @@ describe('ClipboardManager.loadHistory', () => {
         manager.dispose();
     });
 });
+
+describe('ClipboardManager.dispose', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(realOs.tmpdir(), 'cm-dispose-test-'));
+        homedirMock.mockReturnValue(tmpDir);
+        readText.mockReset().mockResolvedValue('');
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        jest.clearAllMocks();
+    });
+
+    it('disposes the window focus listener registered in the constructor', async () => {
+        const disposeSpy = jest.fn();
+        (vscode.window.onDidChangeWindowState as jest.Mock).mockReturnValueOnce({ dispose: disposeSpy });
+
+        const manager = new ClipboardManager(makeContext());
+        await flushMicrotasks();
+
+        manager.dispose();
+
+        expect(disposeSpy).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Pre-flight Check

Open PRs and active routine branches checked before starting (Phase 1):

- #53 `routine/qp-fix-skillgen-backslash-regex-260714` — `src/mcp/SkillGenerator.ts`
- #52 `routine/qp-fix-hover-provider-id-mismatch-260713` — `src/promptHoverProvider.ts`
- #51 `routine/qp-fix-debug-log-path-leak-260710` — `src/ai/aiEngine.ts`, `src/extension.ts`
- #50 `routine/qp-fix-privacy-unmask-duplicate-260709` — `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts`
- #49 `routine/qp-fix-backup-log-path-leak-260708` — `src/core/PromptManager.ts`
- #48 `routine/qp-fix-versionmanager-malformed-json-260707` — `src/core/VersionManager.ts`, `src/test/unit/versionManager.test.ts`
- #47 `routine/qp-fix-mcp-clipboard-non-array-260706` — `mcp-server/src/tools/clipboardTools.ts`
- #46 `routine/qp-fix-versionhistory-substr-260703` — `src/services/VersionHistoryService.ts`
- #45 `chore/ignore-claude-worktrees-jest` — `jest.config.js`
- #44 `routine/qp-fix-path-traversal-prefix-260702` — `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts`

Also inspected several older `routine/qp-fix-*` branches with no open PR (e.g. `-260625` through `-260701`); their associated PRs are all `CLOSED` (not merged) and their diffs are stale relative to current `master`, so they were disregarded.

This PR touches only `src/ClipboardManager.ts` and `src/test/unit/clipboardManager.test.ts`, neither of which appears in any open PR above — no overlap.

## Changes

`ClipboardManager.registerWindowFocusListener()` registers a `vscode.window.onDidChangeWindowState` listener but never stored the returned `Disposable`. `dispose()` cleaned up the config-change listener and polling interval, but not this one, so every `ClipboardManager` instance leaked a window-state listener. Fixed by storing the disposable in a new `windowStateListener` field and disposing it in `dispose()`. Added a regression test that overrides the mocked `onDidChangeWindowState` to return a spy and asserts it's called once `dispose()` runs (verified the test fails without the fix).

This PR does not modify any MCP tool schema (`mcp-server/src/tools/`) and does not add, remove, or update any dependency.

## Safety Verification

Commands run locally, in order:

- `npx tsc -p ./` — passed, no type errors.
- `npx jest src/test/unit/clipboardManager.test.ts --runInBand` — passed, 13/13 tests (including the new regression test).
- Reverted the fix temporarily (`git stash`) and re-ran the new test to confirm it fails without the change (it did: `Expected number of calls: 1, Received number of calls: 0`), then restored the fix.
- `npm run test` (full suite, `jest --runInBand`) — passed, 111/111 tests across 7 suites.

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json` / `package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release-ready-label gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.