### PR TITLE
[Routine - QP] fix: correct index offset for multiple matches in PatternRegistry.mask

### DIFF
--- a/src/privacy/patternRegistry.ts
+++ b/src/privacy/patternRegistry.ts
@@ -144,10 +144,13 @@ export class PatternRegistry {
             // 重新建立 regex 以重置 lastIndex
             const regex = new RegExp(pattern.regex.source, pattern.regex.flags);
             const matches = Array.from(maskedText.matchAll(regex));
+            // matches 的 index 是相對於此 pattern 開始時的 maskedText 快照；
+            // 同一 pattern 內每次替換都可能改變長度，須用 offset 校正後續 match 的位置。
+            let offset = 0;
 
             for (const match of matches) {
                 if (match.index === undefined) { continue; }
-                const start = match.index;
+                const start = match.index + offset;
                 const end = start + match[0].length;
 
                 if (this.isOverlapping(start, end, maskedRanges)) { continue; }
@@ -156,9 +159,12 @@ export class PatternRegistry {
                 tokens.push(token);
 
                 maskedText = maskedText.substring(0, start) + token.maskedValue + maskedText.substring(end);
-                maskedRanges.push({ start, end });
+                // 記錄的範圍要對應「取代後」文字中 token 實際佔用的區間，而非原始 match 的長度，
+                // 否則後續 pattern 的重疊判斷會用到錯誤座標。
+                maskedRanges.push({ start, end: start + token.maskedValue.length });
 
                 const diff = token.maskedValue.length - match[0].length;
+                offset += diff;
                 for (const r of maskedRanges) {
                     if (r.start > start) { r.start += diff; r.end += diff; }
                 }

--- a/src/test/unit/patternRegistry.test.ts
+++ b/src/test/unit/patternRegistry.test.ts
@@ -1,0 +1,33 @@
+import { PatternRegistry } from '../../privacy/patternRegistry';
+import { PREDEFINED_PATTERNS } from '../../privacy/masking/patternEngine';
+
+describe('PatternRegistry.mask', () => {
+    let registry: PatternRegistry;
+
+    beforeEach(() => {
+        registry = new PatternRegistry();
+        registry.loadBuiltIn(PREDEFINED_PATTERNS);
+    });
+
+    it('masks every occurrence when a pattern matches multiple times and the label length differs from the match length', () => {
+        const text = 'contact alice@example.com or bob@example.com today';
+        const { maskedText, tokens } = registry.mask(text);
+
+        expect(maskedText).toBe('contact [EMAIL-1] or [EMAIL-2] today');
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0].originalValue).toBe('alice@example.com');
+        expect(tokens[1].originalValue).toBe('bob@example.com');
+        // No fragment of either original email should leak into the output.
+        expect(maskedText).not.toContain('alice@example.com');
+        expect(maskedText).not.toContain('bob@example.com');
+        expect(maskedText).not.toContain('@example.com');
+    });
+
+    it('masks three or more occurrences of the same pattern correctly', () => {
+        const text = 'a@x.com, b@x.com, c@x.com';
+        const { maskedText, tokens } = registry.mask(text);
+
+        expect(maskedText).toBe('[EMAIL-1], [EMAIL-2], [EMAIL-3]');
+        expect(tokens.map(t => t.originalValue)).toEqual(['a@x.com', 'b@x.com', 'c@x.com']);
+    });
+});


### PR DESCRIPTION
## Pre-flight Check

Checked all currently open PRs (#44–#55) and their changed files before selecting a target, to avoid duplicating in-flight work:

| PR | Files touched |
|----|----------------|
| #44 | `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts` |
| #45 | `jest.config.js` |
| #46 | `src/services/VersionHistoryService.ts` |
| #47 | `mcp-server/src/tools/clipboardTools.ts` |
| #48 | `src/core/VersionManager.ts`, `src/test/unit/versionManager.test.ts` |
| #49 | `src/core/PromptManager.ts` |
| #50 | `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts` |
| #51 | `src/ai/aiEngine.ts`, `src/extension.ts` |
| #52 | `src/promptHoverProvider.ts` |
| #53 | `src/mcp/SkillGenerator.ts` |
| #54 | `src/ClipboardManager.ts`, `src/test/unit/clipboardManager.test.ts` |
| #55 | `mcp-server/src/index.ts` |

This PR only touches `src/privacy/patternRegistry.ts` (new test file `src/test/unit/patternRegistry.test.ts`), which is not modified or referenced by any open PR, so there is no overlap. It also does not touch any file under `mcp-server/src/tools/`.

## Changes

`PatternRegistry.mask()` (`src/privacy/patternRegistry.ts`) collects all regex matches for a pattern once via `matchAll()` *before* performing any replacements. Because masked labels (e.g. `[EMAIL-1]`) are almost always shorter than the real matched value, replacing an earlier match shifts the text — but later matches in the same batch still used their original, now-stale indices. Two consequences:

1. **Text corruption / leaked fragments**: applying a later match at a stale index sliced the already-shortened string at the wrong position, corrupting the output and in some cases leaving a fragment of the original sensitive value (e.g. part of a second email address) visible in the "masked" text.
2. **Skipped matches**: the overlap-tracking ranges were recorded using the *original* match length instead of the replacement token's length, which could make a later, legitimately non-overlapping match look like it overlapped a prior replacement and get silently skipped (so it was never masked at all).

Fix: track a running `offset` accumulated from each replacement's length delta and apply it to subsequent match positions within the same pattern, and record the overlap-tracking range using the token's actual replacement length rather than the original match length. Added `src/test/unit/patternRegistry.test.ts` with regression tests for 2 and 3 same-type matches in one string, asserting the original values no longer appear anywhere in the masked output.

Confirms this PR does not modify any MCP tool schema, name, or parameter in `mcp-server/src/tools/`, and does not add/remove/update any dependency.

## Safety Verification

Commands run locally, in order:

```
npx tsc -p ./          # passed, no errors
npx jest --runInBand   # 8 suites passed, 112 tests passed (incl. 2 new)
```

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.