### PR TITLE
[Routine - QP] fix: avoid logging full workspace paths in mcp-server/src/server.ts

### DIFF
--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -419,7 +419,7 @@ export class QuickPromptMCPServer {
     });
     this.primaryWorkspaceId = id;
 
-    this.log('info', `Workspace [${name}] initialized from CLI: ${resolvedPath}`);
+    this.log('info', `Workspace [${name}] initialized from CLI: ${path.basename(resolvedPath)}`);
   }
 
   private static toWorkspaceUri(rootPath: string): string {
@@ -487,12 +487,12 @@ export class QuickPromptMCPServer {
           if (!this.primaryWorkspaceId) {
             this.primaryWorkspaceId = id;
           }
-          this.log('info', `Workspace [${name}] loaded from MCP Roots: ${resolvedPath}`);
+          this.log('info', `Workspace [${name}] loaded from MCP Roots: ${path.basename(resolvedPath)}`);
         } else {
-          this.log('warning', `Root path is not a directory: ${rootPath}`);
+          this.log('warning', `Root path is not a directory: ${path.basename(rootPath)}`);
         }
       } catch (error) {
-        this.log('error', `Cannot access root path ${rootPath}`, error instanceof Error ? error.message : String(error));
+        this.log('error', `Cannot access root path ${path.basename(rootPath)}`, error instanceof Error ? error.message : String(error));
       }
     }
   }
@@ -724,7 +724,7 @@ export class QuickPromptMCPServer {
         if (!workspaceRoot) {
           this.log('error', 'Error: cannot obtain workspace path. Please specify one via command-line arguments, or use a client that supports MCP Roots.');
         } else {
-          this.log('info', `Using command-line specified workspace: ${workspaceRoot}`);
+          this.log('info', `Using command-line specified workspace: ${path.basename(workspaceRoot)}`);
         }
       }
     };


### PR DESCRIPTION
## Pre-flight Check

Open PRs / active routine branches checked (13 open, all draft, all `mergeStateStatus: CLEAN` except #52 `UNSTABLE`):

| PR | Branch | Files touched |
|----|--------|---------------|
| #44 | routine/qp-fix-path-traversal-prefix-260702 | `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts` |
| #45 | chore/ignore-claude-worktrees-jest | `jest.config.js` |
| #46 | routine/qp-fix-versionhistory-substr-260703 | `src/services/VersionHistoryService.ts` |
| #47 | routine/qp-fix-mcp-clipboard-non-array-260706 | `mcp-server/src/tools/clipboardTools.ts` |
| #48 | routine/qp-fix-versionmanager-malformed-json-260707 | `src/core/VersionManager.ts`, `src/test/unit/versionManager.test.ts` |
| #49 | routine/qp-fix-backup-log-path-leak-260708 | `src/core/PromptManager.ts` |
| #50 | routine/qp-fix-privacy-unmask-duplicate-260709 | `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts` |
| #51 | routine/qp-fix-debug-log-path-leak-260710 | `src/ai/aiEngine.ts`, `src/extension.ts` |
| #52 | routine/qp-fix-hover-provider-id-mismatch-260713 | `src/promptHoverProvider.ts` |
| #53 | routine/qp-fix-skillgen-backslash-regex-260714 | `src/mcp/SkillGenerator.ts` |
| #54 | routine/qp-fix-clipboard-window-listener-leak-260715 | `src/ClipboardManager.ts`, `src/test/unit/clipboardManager.test.ts` |
| #55 | routine/qp-fix-mcp-workspace-path-leak-260716 | `mcp-server/src/index.ts` |
| #56 | routine/qp-fix-pattern-mask-multimatch-260717 | `src/privacy/patternRegistry.ts`, `src/test/unit/patternRegistry.test.ts` |

This PR touches only `mcp-server/src/server.ts`, which is not modified by any of the above. No overlap.

## Changes

`QuickPromptMCPServer` (in `mcp-server/src/server.ts`) logs workspace/root path information at several points (`updateWorkspaceRoot`, `updateWorkspaceFromRoots`, `connect`'s `oninitialized` handler). Five of these `this.log(...)` calls interpolated the *full resolved path* into the message, which is then written to stderr and sent as an MCP logging notification to the connected client — leaking the user's local directory structure/username in logs.

This is the same class of issue already fixed in sibling files by #49 (`PromptManager.ts`), #51 (`aiEngine.ts` / `extension.ts`), and #55 (`mcp-server/src/index.ts`), but `mcp-server/src/server.ts` itself was never covered. This PR applies the identical, already-established fix: replace the full path with `path.basename(...)` in each log message.

- Does not modify any MCP tool schema, name, or parameter in `mcp-server/src/tools/` (only `mcp-server/src/server.ts`'s internal logging was touched).
- Does not add, remove, or update any dependency.
- Does not modify `package.json`, `package-lock.json`, or `CHANGELOG.md`.

## Safety Verification

Commands run locally, from repo root:

- `npx tsc -p ./` — passed, no errors.
- `npm run test` (`jest --runInBand`) — passed: 7 suites, 110 tests, 0 failures.

(No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine-task instructions.)

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's release-readiness/version-bump gate, that is expected behavior for a routine PR, not a code validation failure.