### PR TITLE
[Routine - QP] fix: avoid logging full workspace path in validateWorkspaceRoot catch block

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -92,7 +92,8 @@ function validateWorkspaceRoot(workspaceRoot: string): boolean {
     }
     return true;
   } catch (error) {
-    console.error(`[WARNING] Failed to validate workspace path: ${error}`);
+    const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+    console.error(`[WARNING] Failed to validate workspace path: ${path.basename(workspaceRoot)}${code ? ` (${code})` : ''}`);
     return false;
   }
 }


### PR DESCRIPTION
## Pre-flight Check

Open PRs at the time of this run:
- #58 `release/v0.6.0-260722` — release prep (workflows/CHANGELOG/package.json) — not code.
- #56 `routine/qp-fix-pattern-mask-multimatch-260717` — touches `src/privacy/patternRegistry.ts`.
- #50 `routine/qp-fix-privacy-unmask-duplicate-260709` — touches `src/core/PrivacyManager.ts`.
- #44 `routine/qp-fix-path-traversal-prefix-260702` — touches `src/core/PathUtils.ts`.

Other `routine/qp-fix-*` remote branches exist but correspond to already-merged PRs (their commits are on `master`, e.g. the ClipboardManager listener disposal, hover-provider ID parsing, skill path regex, and several path-logging fixes in #46–#57).

This PR touches only `mcp-server/src/index.ts`, which none of the open PRs or recent merges modify. No overlap.

## Changes

`validateWorkspaceRoot()`'s `catch` block still interpolated the raw `error` object directly into the log message:

```ts
console.error(`[WARNING] Failed to validate workspace path: ${error}`);
```

Node's `fs.statSync`/`fs.existsSync` errors (e.g. `EACCES`) stringify with the full path embedded in `error.message`. Every other log line in this same function/file was already redacted to `path.basename()` back in PR #55 ("avoid logging full workspace path in MCP server stderr"), but this one catch-all branch was missed. This change brings it in line with the rest of the file: log the basename plus the error `code` (when available) for diagnostics, without leaking the full path.

- Does **not** modify any MCP tool schema/name/parameters under `mcp-server/src/tools/`.
- Does **not** add/remove/update any dependency.
- Does **not** touch `package.json`, `package-lock.json`, or `CHANGELOG.md`.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — clean, no errors.
- `npm run build:mcp` — esbuild bundle succeeds.
- Unit tests (`jest --runInBand --coverage`, excluding the extest-based UI suites which require a separate VS Code test harness): **7 suites / 113 tests passed**, coverage thresholds met (statements 95.69%, branches 91.02%, functions 96.82%, lines 95.75% — all above the configured 80/70/80/80 gate).

Note: running `npm run test:coverage` verbatim reports "No tests found" in this environment because the checkout lives under a `.claude/worktrees/...` path, and `jest.config.js`'s `/.claude/` ignore pattern (added in PR #45 to skip bundled skill copies) unintentionally matches the worktree path prefix itself. This is a pre-existing environment quirk unrelated to this change; test files were run directly with an equivalent ignore-pattern override to confirm they pass.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)