### PR TITLE
[Routine - QP] fix: anchor jest .claude ignore pattern to rootDir

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     testMatch: ['**/src/test/**/*.test.ts'],
-    testPathIgnorePatterns: ['/node_modules/', '/src/test/ui/', '/.vscode-test/', '/.claude/'],
+    testPathIgnorePatterns: ['/node_modules/', '/src/test/ui/', '/.vscode-test/', '<rootDir>/.claude/'],
     modulePathIgnorePatterns: ['<rootDir>/.vscode-test/', '<rootDir>/.claude/', '<rootDir>/dist/'],
     transform: {
         '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (via `gh pr list --state open`):
- #61 `dependabot/npm_and_yarn/...` — touches `package-lock.json` only
- #56 `routine/qp-fix-pattern-mask-multimatch-260717` — touches `src/privacy/patternRegistry.ts`, `src/test/unit/patternRegistry.test.ts`
- #50 `routine/qp-fix-privacy-unmask-duplicate-260709` — touches `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts`
- #44 `routine/qp-fix-path-traversal-prefix-260702` — touches `src/core/PathUtils.ts`, `src/test/unit/pathUtils.test.ts`

Active remote branches were also inspected (`git branch -r` + `git diff origin/master...origin/<branch> --stat`). Most `routine/qp-fix-*` branches turned out to be already merged/subsumed into `master` (content-identical, per prior squash-merge verification learnings) and stale, not pending work — e.g. `chore/ignore-claude-worktrees-jest` is byte-identical to what's already on `master`. Feature/release branches (`chore/issue-25-skill-install-scope`, `fix/quick-create-workspace-ux`, `release/qp-0.5.7-integration`, `release/v0.6.0-260722`, `docs/v0.5.3-landing-page`) touch `src/commands.ts`, `src/promptProvider.ts`, `src/services/VersionHistoryService.ts`, `src/core/PrivacyManager.ts`, `src/core/PromptManager.ts`, `src/core/VersionManager.ts`, `package.json`, `CHANGELOG.md`, `docs/index.html`, etc.

This PR touches only `jest.config.js`, which none of the above touch — no overlap.

## Changes

`jest.config.js`'s `testPathIgnorePatterns` included an unanchored `/.claude/` entry (meant to skip a nested `.claude` worktree copy inside the repo). Because the pattern isn't anchored to `<rootDir>`, it matches on any absolute path *containing* that substring — including the ancestor directories of the checkout itself. When the repository is checked out inside a `.claude/worktrees/...` directory (exactly how Claude Code worktrees, including this automated routine task, check out the repo), **every** test file path matches the pattern and `jest` reports "No tests found", causing `npm run test` to always fail in that setup.

Fix: anchor the entry to `<rootDir>/.claude/`, matching the style already used one line below in `modulePathIgnorePatterns`. This restricts the ignore to a `.claude` directory nested *inside* the project, not ancestor directories of the checkout, while preserving the original intent.

This PR does not modify any MCP tool schema (`mcp-server/src/tools/`), does not add/remove/update dependencies, and does not touch `package.json`/`package-lock.json`/`CHANGELOG.md`.

## Safety Verification

Commands run locally (from a worktree under `.claude/worktrees/...`, reproducing the bug):

- `npx tsc -p ./` → passed, no errors
- `npm run test` (`jest --runInBand`) → **before fix:** `No tests found, exiting with code 1` (0 test files matched despite 10 matching `testMatch`). **After fix:** `Test Suites: 7 passed, 7 total / Tests: 113 passed, 113 total`

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.