### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "Quick Prompt" extension will be documented in this file.
 
+## [0.6.0] - Stable Release: High-Risk Security & Privacy Fixes - 2026-07-26
+
+### 🐛 Bug Fixes
+
+- **fix(PathUtils):** close prefix-match bypass in `validatePath` — a sibling directory merely sharing a name prefix with the workspace root (e.g. `/foo/bar-evil` vs `/foo/bar`) was incorrectly accepted as inside the workspace boundary (#44)
+- **fix(PrivacyManager):** restore all occurrences when unmasking repeated privacy tokens — `unmaskText` previously only restored the first occurrence of a repeated masked value (#50)
+- **fix(PatternRegistry):** correct index offset for multiple matches in `mask()` — when a pattern matched more than once and the label length differed from the match length, later matches in the same pass were masked at the wrong position (#56)
+
 ## [0.5.8] - Privacy & Stability Fixes (pre-release) - 2026-07-22
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quick-prompt",
-    "version": "0.5.8",
+    "version": "0.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quick-prompt",
-            "version": "0.5.8",
+            "version": "0.6.0",
             "license": "MIT",
             "dependencies": {
                 "@huggingface/transformers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "quick-prompt",
     "displayName": "Quick Prompt - Capture Ideas & Queue Tasks While AI Works",
     "description": "%extension.description%",
-    "version": "0.5.8",
+    "version": "0.6.0",
     "publisher": "winterdrive",
     "icon": "docs/assets/quickprompt_icon_128.png",
     "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps version to 0.6.0 (even minor → stable tier per versioning convention)
- Promotes three previously-deferred high-risk fixes to stable:
  - #44: PathUtils prefix-match bypass in `validatePath`
  - #50: PrivacyManager repeated-occurrence unmask
  - #56: PatternRegistry multi-match index offset

## Test plan
- [x] All three fixes verified together in an isolated git worktree (independent node_modules/.vscode-test, no shared state with the main checkout)
- [x] Full unit suite (`npm test`): 119/119 passing
- [x] Full E2E suite (`npm run test:ui`): 13 passing
- [x] Follow-up issue filed for an unrelated, pre-existing edge case found during review: winterdrive/vscode-quick-prompt#63 (custom dictionary label substring collision in `unmaskText`)