### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "Quick Prompt" extension will be documented in this file.
 
+## [0.7.0] - Maintenance (pre-release) - 2026-07-26
+
+### 🔧 Maintenance
+
+- **test:** anchor jest `.claude` ignore pattern to `rootDir` (#62)
+- **chore(deps):** bump the `npm_and_yarn` dependency group across 1 directory with 6 updates (#61)
+
 ## [0.6.0] - Stable Release: High-Risk Security & Privacy Fixes - 2026-07-26
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quick-prompt",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quick-prompt",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "license": "MIT",
             "dependencies": {
                 "@huggingface/transformers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "quick-prompt",
     "displayName": "Quick Prompt - Capture Ideas & Queue Tasks While AI Works",
     "description": "%extension.description%",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "publisher": "winterdrive",
     "icon": "docs/assets/quickprompt_icon_128.png",
     "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps version to 0.7.0 (odd minor → pre-release tier per versioning convention)
- Includes #62 (jest .claude ignore pattern fix) and #61 (routine dependency bump)

## Test plan
- [x] Full unit suite (`npm test`): 119/119 passing, verified locally after a clean `npm ci` against the updated lockfile