### PR TITLE
[Routine - QP] fix: guard PrivacyManager dictionary load against malformed JSON shape

### DIFF
--- a/src/core/PrivacyManager.ts
+++ b/src/core/PrivacyManager.ts
@@ -298,10 +298,23 @@ export class PrivacyManager {
         }
         try {
             const content = fs.readFileSync(this.dictionaryPath, 'utf-8');
-            return JSON.parse(content) as DictionaryFile;
+            const parsed: unknown = JSON.parse(content);
+            if (!PrivacyManager.isValidDictionaryFile(parsed)) {
+                throw new Error('Malformed privacy dictionary shape');
+            }
+            return parsed;
         } catch {
             return { version: '1.0', description: 'Quick Prompt Privacy Dictionary', lastModified: new Date().toISOString(), entries: [] };
         }
+    }
+
+    /**
+     * Guards against a privacy-dictionary.json that parses successfully but has
+     * an unexpected shape (e.g. `{}`, `null`, `{"entries": null}`), which would
+     * otherwise throw later on `data.entries.push/find/findIndex`.
+     */
+    private static isValidDictionaryFile(value: unknown): value is DictionaryFile {
+        return !!value && typeof value === 'object' && Array.isArray((value as DictionaryFile).entries);
     }
 
     private saveDictionary(data: DictionaryFile): void {

--- a/src/test/unit/privacyManager.test.ts
+++ b/src/test/unit/privacyManager.test.ts
@@ -41,4 +41,35 @@ describe('PrivacyManager', () => {
             expect(manager.unmaskText(maskedText)).toBe(original);
         });
     });
+
+    // ── dictionary file shape guard ──────────────────────────────────────────
+
+    describe('dictionary CRUD with malformed privacy-dictionary.json', () => {
+        const writeDictionaryFile = (content: string) => {
+            const dictDir = path.join(tmpDir, '.vscode');
+            fs.mkdirSync(dictDir, { recursive: true });
+            fs.writeFileSync(path.join(dictDir, 'privacy-dictionary.json'), content, 'utf-8');
+        };
+
+        it('falls back to an empty dictionary instead of throwing when entries is missing', () => {
+            writeDictionaryFile('{}');
+
+            expect(manager.getDictionaryEntries()).toEqual([]);
+            expect(() =>
+                manager.addDictionaryEntry({ pattern: 'ACME', isRegex: false, label: '[COMPANY]', enabled: true })
+            ).not.toThrow();
+        });
+
+        it('falls back to an empty dictionary instead of throwing when entries is null', () => {
+            writeDictionaryFile(JSON.stringify({ version: '1.0', entries: null }));
+
+            expect(manager.getDictionaryEntries()).toEqual([]);
+        });
+
+        it('falls back to an empty dictionary instead of throwing when the file is a bare array', () => {
+            writeDictionaryFile('[]');
+
+            expect(manager.getDictionaryEntries()).toEqual([]);
+        });
+    });
 });


### PR DESCRIPTION
## Pre-flight Check

**Open PRs at time of run:** none (`gh pr list --state open` returned `[]`).

**Active remote routine branches checked:** all 20 `routine/qp-fix-*` branches on origin were checked via `gh pr list --state all`; every one of them already has a MERGED (or, for the 4 stale ones, CLOSED-without-overlap) PR, so none represent in-flight work. Notably `routine/qp-fix-ai-progress-cleanup-260629` (closed PR #39, targeting `src/ai/aiEngine.ts`) was already superseded — its `try/finally` + `.then(undefined, ...)` fix is present in current `master`.

**This PR's file:** `src/core/PrivacyManager.ts` (plus its test file `src/test/unit/privacyManager.test.ts`). Neither file appears in any of the above (merged or closed) branch diffs, so there is no overlap.

## Changes

`PrivacyManager.loadDictionary()` (`.vscode/privacy-dictionary.json` reader) parsed JSON with a bare `JSON.parse(content) as DictionaryFile` cast and only guarded against a JSON *syntax* error. If the file parsed successfully but had an unexpected shape — `{}`, `null`, `{"entries": null}`, or a bare array — `data.entries` would be `undefined`, and the very next call to `getDictionaryEntries()` (`.filter`), `addDictionaryEntry()` (`.push`), `editDictionaryEntry()`/`deleteDictionaryEntry()`/`toggleDictionaryEntry()` (`.findIndex`/`.find`) would throw a `TypeError`, crashing whatever privacy-masking command or MCP flow invoked it.

This mirrors an already-fixed pattern in this codebase (`VersionManager.isValidHistory`): added a `PrivacyManager.isValidDictionaryFile()` type guard that checks `Array.isArray(value.entries)`, and `loadDictionary()` now falls back to the existing empty-dictionary default whenever the parsed shape doesn't match, instead of trusting the cast.

Added 3 regression tests covering `{}`, `{"entries": null}`, and a bare `[]` privacy-dictionary.json.

This PR does **not** modify any MCP tool schema, tool name, or parameter (no files under `mcp-server/src/tools/` touched), and does **not** add/remove/update any dependency.

## Safety Verification

Commands run locally, in order:

```
$ npx tsc -p ./
(no output — exit 0)

$ npm run test
Test Suites: 9 passed, 9 total
Tests:       122 passed, 122 total
Time:        6.053 s
```

(No `lint` or `format:check` script exists in `package.json`, so those steps were skipped as inapplicable.)

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR.

If GitHub Actions fails only because of the repository's release-readiness / version-bump gate, that is expected behavior for a routine PR, not a code-validation failure.