### PR TITLE
[Routine - QP] fix: avoid logging full workspace path in PromptProvider catch blocks

### DIFF
--- a/src/promptProvider.ts
+++ b/src/promptProvider.ts
@@ -27,6 +27,15 @@ export interface WorkspaceConfig {
 // TreeItem 類型 (支援 PromptItem 和 VersionItem)
 export type PromptTreeItem = PromptItem | VersionItem;
 
+/**
+ * 將檔案系統錯誤格式化為安全的日誌訊息：僅保留錯誤代碼，避免將
+ * fs.statSync/readFile 等錯誤訊息中內嵌的完整工作區路徑寫入日誌。
+ */
+function formatFsErrorForLog(error: unknown): string {
+    const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+    return code ?? (error instanceof Error ? error.name : 'unknown error');
+}
+
 export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
     private static readonly scopeStateKey = 'quickPrompt.activeWorkspaceScope';
     private static readonly lastCreateWorkspaceStateKey = 'quickPrompt.lastCreateWorkspaceKey';
@@ -230,7 +239,7 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
                 allPrompts = allPrompts.concat(processedPrompts);
                 loadedWorkspaceKeys.add(config.key);
             } catch (error) {
-                console.error(`Failed to load prompts for workspace ${config.name}:`, error);
+                console.error(`Failed to load prompts for workspace ${config.name}: ${formatFsErrorForLog(error)}`);
                 failedWorkspaceKeys.add(config.key);
             }
         }
@@ -268,7 +277,7 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
 
             vscode.window.showInformationMessage(`✨ 已在 ${config.name} 建立預設 Prompt 檔案`);
         } catch (error) {
-            console.error(`Failed to create default prompts file for ${config.name}:`, error);
+            console.error(`Failed to create default prompts file for ${config.name}: ${formatFsErrorForLog(error)}`);
             throw error;
         }
     }
@@ -325,7 +334,7 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
             }
             this._onPromptsChanged.fire(); // 通知 FileSystem 同步
         } catch (error) {
-            console.error('Failed to save prompts:', error);
+            console.error(`Failed to save prompts: ${formatFsErrorForLog(error)}`);
             throw error;
         } finally {
             setTimeout(() => { this._savingCount--; }, 300);
@@ -343,7 +352,7 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
             await vscode.workspace.fs.writeFile(uri, Buffer.from(content, 'utf8'));
             this.loadedWorkspaceKeys.add(config.key);
         } catch (error) {
-            console.error(`Failed to save prompts for ${config.name}:`, error);
+            console.error(`Failed to save prompts for ${config.name}: ${formatFsErrorForLog(error)}`);
         } finally {
             setTimeout(() => { this._savingCount--; }, 300);
         }


### PR DESCRIPTION
## 1. Pre-flight Check

- Open PRs at time of writing: #66 `routine/qp-fix-privacy-dictionary-shape-260727` — touches `src/core/PrivacyManager.ts` and `src/test/unit/privacyManager.test.ts` (guards dictionary load against malformed JSON shape).
- Active routine branches on remote (recent, unmerged into this PR's scope): `routine/qp-fix-ai-progress-cleanup-260629`, `routine/qp-fix-backup-log-path-leak-260708`, `routine/qp-fix-clipboard-window-listener-leak-260715`, `routine/qp-fix-corrupted-clipboard-json-260626`, `routine/qp-fix-debug-log-path-leak-260710`, `routine/qp-fix-hover-provider-id-mismatch-260713`, `routine/qp-fix-mcp-clipboard-non-array-260706`, `routine/qp-fix-mcp-workspace-path-leak-260716`, `routine/qp-fix-non-array-json-260627`, `routine/qp-fix-privacy-dictionary-shape-260727`, `routine/qp-fix-server-workspace-path-leak-260722`, `routine/qp-fix-skillgen-backslash-regex-260714`, `routine/qp-fix-substr-deprecation-260625`, `routine/qp-fix-unused-reply-var-260630`, `routine/qp-fix-validate-path-error-leak-260723`, `routine/qp-fix-version-history-corrupt-json-260701`, `routine/qp-fix-versionhistory-substr-260703`, `routine/qp-fix-versionmanager-malformed-json-260707` (most of these are already merged per `gh pr list --state merged`; branch refs simply weren't pruned).
- This branch touches only `src/promptProvider.ts` — not touched by PR #66, and distinct from every merged path-leak fix (`PromptManager.ts`, `mcp-server/src/index.ts`, `mcp-server/src/server.ts`, `extension.ts`, `aiEngine.ts`), which never covered this file.

## 2. Changes

`src/promptProvider.ts` had four `catch (error)` blocks (in `loadPrompts`, `createDefaultPromptsFileForConfig`, `savePrompts`, `savePromptsForConfig`) that logged the raw `error` object via `console.error`. For `vscode.workspace.fs` failures (e.g. `ENOENT`/`EACCES`), the error's `message` embeds the fully resolved absolute path to the user's `.vscode/prompts.json`, leaking local filesystem layout into extension debug output — the same class of issue fixed in prior merged PRs (#49, #51, #55, #57, #59) for other files, but never addressed here.

Added a small `formatFsErrorForLog()` helper that extracts only the error code (or error name as fallback) and used it in all four catch blocks in place of the raw error object, matching the precedent set in `mcp-server/src/index.ts`'s `validateWorkspaceRoot` (PR #59).

- Does not modify any MCP tool schema, name, or parameters in `mcp-server/src/tools/`.
- Does not add, remove, or update any dependency.
- Does not modify `package.json`, `package-lock.json`, or `CHANGELOG.md`.

## 3. Safety Verification

Commands run locally, all passed:

- `npx tsc -p ./` → no errors.
- `npm run test:coverage` → `Test Suites: 9 passed, 9 total`, `Tests: 119 passed, 119 total`.

No `lint` or `format:check` npm script exists in `package.json`, so those steps were skipped per the project's available scripts.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior, not a code validation failure.