### PR TITLE
[Routine - QP] fix: disable command-link trust on hover/tooltip MarkdownStrings

### DIFF
--- a/src/promptHoverProvider.ts
+++ b/src/promptHoverProvider.ts
@@ -66,7 +66,10 @@ export class PromptHoverProvider implements vscode.HoverProvider {
     private createPromptHoverMarkdown(prompt: Prompt): vscode.MarkdownString {
         const md = new vscode.MarkdownString();
         md.supportHtml = true;
-        md.isTrusted = true;
+        // isTrusted intentionally left false: prompt title/content is user-controlled
+        // (and may come from a shared, version-controlled prompts.json), and isTrusted
+        // would let a crafted `[label](command:...)` markdown link execute VS Code
+        // commands. Nothing here needs command links.
 
         // 標題
         md.appendMarkdown(`## ${prompt.pinned ? '📌 ' : ''}${prompt.title}\n\n`);

--- a/src/treeItems/VersionItem.ts
+++ b/src/treeItems/VersionItem.ts
@@ -94,7 +94,9 @@ export class VersionItem extends vscode.TreeItem {
     private static getTooltip(version: PromptVersion, isCurrent: boolean): vscode.MarkdownString {
         const tooltip = new vscode.MarkdownString();
         tooltip.supportHtml = true;
-        tooltip.isTrusted = true;
+        // isTrusted intentionally left false: version content/milestone labels are
+        // user-controlled, and isTrusted would let a crafted `[label](command:...)`
+        // markdown link execute VS Code commands. Nothing here needs command links.
 
         // Header
         if (isCurrent) {


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (Phase 1):
- #67 `routine/qp-fix-promptprovider-path-leak-260728` — touches `src/promptProvider.ts`
- #66 `routine/qp-fix-privacy-dictionary-shape-260727` — touches `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts`

This PR touches `src/promptHoverProvider.ts` and `src/treeItems/VersionItem.ts`, which are not modified by either open PR — no overlap.

## Changes

`PromptHoverProvider.createPromptHoverMarkdown()` and `VersionItem.getTooltip()` both built a `vscode.MarkdownString` with `isTrusted = true` while interpolating user-controlled data directly into the markdown (`prompt.title`, `version.milestone.label`). `isTrusted` is specifically what allows `[label](command:...)` markdown links to render as clickable, command-executing links. Neither the hover preview nor the version tooltip renders any command links, so the trust elevation was unnecessary attack surface: since `prompts.json` / version history can be shared or version-controlled across a team, a crafted title or milestone label could otherwise let a teammate trigger a VS Code command just by hovering over a prompt or a version entry.

Removed `isTrusted = true` from both call sites (left `supportHtml` untouched since it has no effect without `isTrusted` and isn't the concern here). No behavior change for legitimate content — plain markdown (headers, bold, code blocks, emoji) renders the same either way.

Confirms this PR does not modify any MCP tool schema (`mcp-server/src/tools/`) and does not add/remove/update any dependencies.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (jest) — 9 test suites, 119 tests, all passed

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.