### PR TITLE
[Routine - QP] fix: guard SecretStorageManager against malformed token map shape

### DIFF
--- a/src/privacy/masking/secretStorage.ts
+++ b/src/privacy/masking/secretStorage.ts
@@ -19,7 +19,8 @@ export class SecretStorageManager {
         const raw = await this.secrets.get(KEY_PREFIX + promptId);
         if (!raw) { return undefined; }
         try {
-            return JSON.parse(raw) as Record<string, string>;
+            const parsed: unknown = JSON.parse(raw);
+            return SecretStorageManager.isValidTokenMap(parsed) ? parsed : undefined;
         } catch {
             return undefined;
         }
@@ -27,5 +28,17 @@ export class SecretStorageManager {
 
     async delete(promptId: string): Promise<void> {
         await this.secrets.delete(KEY_PREFIX + promptId);
+    }
+
+    /**
+     * Guards against secret-storage content that parses successfully but isn't a
+     * plain string map (e.g. an array or a value with non-string entries), which
+     * would otherwise corrupt prompt content when unmaskPromptContent iterates it.
+     */
+    private static isValidTokenMap(value: unknown): value is Record<string, string> {
+        return !!value
+            && typeof value === 'object'
+            && !Array.isArray(value)
+            && Object.values(value).every(v => typeof v === 'string');
     }
 }

--- a/src/test/unit/secretStorage.test.ts
+++ b/src/test/unit/secretStorage.test.ts
@@ -1,0 +1,55 @@
+import { SecretStorageManager } from '../../privacy/masking/secretStorage';
+
+class FakeSecretStorage {
+    private data = new Map<string, string>();
+
+    async get(key: string): Promise<string | undefined> {
+        return this.data.get(key);
+    }
+
+    async store(key: string, value: string): Promise<void> {
+        this.data.set(key, value);
+    }
+
+    async delete(key: string): Promise<void> {
+        this.data.delete(key);
+    }
+
+    setRaw(key: string, raw: string): void {
+        this.data.set(key, raw);
+    }
+}
+
+describe('SecretStorageManager', () => {
+    let secrets: FakeSecretStorage;
+    let manager: SecretStorageManager;
+
+    beforeEach(() => {
+        secrets = new FakeSecretStorage();
+        manager = new SecretStorageManager(secrets as unknown as ConstructorParameters<typeof SecretStorageManager>[0]);
+    });
+
+    it('round-trips a valid token map', async () => {
+        await manager.store('p1', { '[NAME-1]': 'Alice' });
+        await expect(manager.retrieve('p1')).resolves.toEqual({ '[NAME-1]': 'Alice' });
+    });
+
+    it('returns undefined when nothing is stored', async () => {
+        await expect(manager.retrieve('missing')).resolves.toBeUndefined();
+    });
+
+    it('returns undefined instead of throwing when the stored value is unparsable JSON', async () => {
+        secrets.setRaw('quickPrompt.tokenMap.p1', 'not-json');
+        await expect(manager.retrieve('p1')).resolves.toBeUndefined();
+    });
+
+    it('returns undefined instead of a corrupting value when the stored JSON is a bare array', async () => {
+        secrets.setRaw('quickPrompt.tokenMap.p1', JSON.stringify(['a', 'b']));
+        await expect(manager.retrieve('p1')).resolves.toBeUndefined();
+    });
+
+    it('returns undefined when a token map value is not a string', async () => {
+        secrets.setRaw('quickPrompt.tokenMap.p1', JSON.stringify({ '[NAME-1]': 123 }));
+        await expect(manager.retrieve('p1')).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs checked before selecting this target:

| PR | Branch | Files touched |
|----|--------|----------------|
| #68 | `routine/qp-fix-hover-tooltip-command-trust-260730` | `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts` |
| #67 | `routine/qp-fix-promptprovider-path-leak-260728` | `src/promptProvider.ts` |
| #66 | `routine/qp-fix-privacy-dictionary-shape-260727` | `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts` |

All other `routine/qp-fix-*` remote branches correspond to already-merged or already-closed PRs (verified via `gh pr list --state all`), so they're not active work in progress.

This PR only touches `src/privacy/masking/secretStorage.ts` (new file for this fix) and adds a new test file `src/test/unit/secretStorage.test.ts`. Neither file overlaps with any file listed above, so there is no conflict with in-flight routine work.

## 2. Changes

`SecretStorageManager.retrieve()` (`src/privacy/masking/secretStorage.ts`) parsed the OS-encrypted secret-storage payload with `JSON.parse` and cast it straight to `Record<string, string>` without validating the actual shape. If the stored value ever parsed successfully but wasn't a plain string map (e.g. an array, or an object with non-string values), the cast would lie about the type. Downstream, `promptProvider.ts#unmaskPromptContent` iterates the result with `Object.entries(...)` and does `content.split(label).join(original)` — with a malformed shape this would silently corrupt the unmasked prompt content instead of failing safely.

Added a private `isValidTokenMap` type guard (object, not an array, all values are strings) and return `undefined` when the shape doesn't hold, so `unmaskPromptContent`'s existing `if (!tokenMap) return false;` check catches it. This mirrors the existing malformed-JSON shape guards already in `PrivacyManager.isValidDictionaryFile` and `VersionHistoryService.isValidHistory`.

Also added `src/test/unit/secretStorage.test.ts` covering: valid round-trip, missing key, unparsable JSON, bare-array payload, and non-string value payload.

This PR does **not** modify any MCP tool schema (`mcp-server/src/tools/`), does not add/remove/update any dependency, and does not touch `package.json`/`package-lock.json`/`CHANGELOG.md`.

## 3. Safety Verification

Commands run locally, in order:

```bash
npx tsc -p ./
npm run test:coverage
```

- `npx tsc -p ./` — passed, no errors.
- `npm run test:coverage` — passed: **10 test suites, 124 tests, all green** (previously 9 suites / 119 tests before this PR's new test file).

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.