### PR TITLE
[Routine - QP] fix: avoid logging raw error object on i18n language file load failure

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -55,7 +55,7 @@ export class I18n {
             console.log(`Successfully loaded ${locale}.json`);
             return true;
         } catch (error) {
-            console.log(`Failed to load ${locale}.json:`, error);
+            console.log(`Failed to load ${locale}.json`);
             return false;
         }
     }


### PR DESCRIPTION
## Pre-flight Check

Checked open PRs and active routine branches before selecting this fix:

- #69 `routine/qp-fix-secretstorage-tokenmap-shape-260731` — touches `src/privacy/masking/secretStorage.ts`, `src/test/unit/secretStorage.test.ts`
- #68 `routine/qp-fix-hover-tooltip-command-trust-260730` — touches `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts`
- #67 `routine/qp-fix-promptprovider-path-leak-260728` — touches `src/promptProvider.ts`
- #66 `routine/qp-fix-privacy-dictionary-shape-260727` — touches `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts`

No other open PRs exist. The remaining `routine/qp-fix-*` remote branches have no open PRs and predate the current `master` history (already squash-merged), so they were not treated as active work-in-progress.

This PR touches only `src/i18n.ts`, which is not modified by any of the above. No overlap.

## Changes

`src/i18n.ts` — `loadLanguageFile()` caught a failed language-file read and logged the raw `error` object via `console.log(..., error)`. Since `vscode.workspace.fs.readFile` throws a `FileSystemError` whose `.message` embeds the full extension install path (e.g. `.../extensions/winterdrive.quick-prompt-x.y.z/i18n/<locale>.json`), this path was printed to the Output console on **every activation** for any VS Code display language other than `en`/`zh-cn`/`zh-tw` (the only locale files that exist). This matches the path-leak pattern already fixed in several other files across prior routine PRs, just missed in `i18n.ts`.

Fix: log a plain message without the raw error object, keeping the locale code (not sensitive) but dropping the leaking error detail.

Confirms this PR does **not** modify any MCP tool schema (`mcp-server/src/tools/`) and does **not** add/remove/update any dependency.

## Safety Verification

Commands run locally, all passed:

- `npx tsc -p ./` — no errors
- `npm run test` — 9 suites, 119 tests passed
- `npm run test:coverage` (CI's actual test command per `.github/workflows/validate.yml`) — 9 suites, 119 tests passed

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.