### PR TITLE
[Routine - QP] fix: dispose previous version-diff content provider before re-registering

### DIFF
--- a/src/commands/versionCommands.ts
+++ b/src/commands/versionCommands.ts
@@ -5,6 +5,11 @@ import { PromptProvider } from '../promptProvider';
 import { I18n } from '../i18n';
 import { executeWithConfirmation } from '../utils';
 
+// VS Code allows only one TextDocumentContentProvider per URI scheme, so we
+// track the active 'prompt-history' registration and dispose it before
+// registering a new one (e.g. when viewing diffs for two versions in quick succession).
+let activeVersionDiffRegistration: vscode.Disposable | undefined;
+
 /**
  * Show diff between a historical version and the current version
  */
@@ -36,7 +41,9 @@ export async function handleShowVersionDiff(
             }
         };
 
+        activeVersionDiffRegistration?.dispose();
         const registration = vscode.workspace.registerTextDocumentContentProvider('prompt-history', provider);
+        activeVersionDiffRegistration = registration;
 
         // Show diff
         const historyLabel = item.version.milestone?.label || new Date(item.version.timestamp).toLocaleString();
@@ -49,8 +56,13 @@ export async function handleShowVersionDiff(
             diffTitle
         );
 
-        // Clean up after a delay
-        setTimeout(() => registration.dispose(), 60000);
+        // Clean up after a delay, unless a newer diff has already replaced this registration
+        setTimeout(() => {
+            if (activeVersionDiffRegistration === registration) {
+                registration.dispose();
+                activeVersionDiffRegistration = undefined;
+            }
+        }, 60000);
     } catch (error) {
         console.error('Failed to show version diff:', error);
         vscode.window.showErrorMessage(I18n.getMessage('message.showDiffFailed'));


### PR DESCRIPTION
## Pre-flight Check

Open PRs and active routine branches checked before selecting this fix (via `gh pr list --state open` and `gh pr diff <n> --name-only`):

| PR | Files touched |
|---|---|
| #70 | `src/i18n.ts` |
| #69 | `src/privacy/masking/secretStorage.ts`, `src/test/unit/secretStorage.test.ts` |
| #68 | `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts` |
| #67 | `src/promptProvider.ts` |
| #66 | `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts` |

This PR only touches `src/commands/versionCommands.ts`, which is not modified by any of the above open PRs. It also does not overlap with any of the many prior closed `routine/qp-fix-*` branches (path-leak logging, malformed-JSON guards, substr deprecation, hover provider fixes, clipboard listener leak, etc. — checked via `git branch -r` and `git log`).

## Changes

`handleShowVersionDiff` in `src/commands/versionCommands.ts` registered a new `vscode.TextDocumentContentProvider` for the `prompt-history` URI scheme on every invocation, but only disposed the old registration via a hard-coded 60-second `setTimeout`. VS Code only allows **one** content provider per scheme at a time, so viewing the diff for a second historical version within that 60-second window threw on the second `registerTextDocumentContentProvider` call — surfacing a spurious "Failed to show version diff" error to the user even though nothing was actually broken.

Fix: track the currently-active registration in a module-level variable, dispose it before creating a new one, and guard the delayed cleanup so it only disposes the registration it created (avoids double-dispose / clobbering a newer registration).

This PR does **not** modify any MCP tool schema, name, or parameter under `mcp-server/src/tools/`, and does not add/remove/update any dependency.

## Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./
npm run test:coverage
```

- Type check: no errors.
- Tests: 9 suites / 119 tests passed (0 failed), coverage report generated normally.
- No existing dedicated test file for `versionCommands.ts`, so risk of regressions elsewhere is minimal; verified via `git log --all -- src/commands/versionCommands.ts` that no test file has ever targeted it.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json` / `package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR — not included here.

If the repository's CI "Validate version bump" gate flags this PR for touching `src/` without a version bump, that is expected release-readiness behavior for a routine PR, not a code validation failure.