### PR TITLE
[Routine - QP] fix: guard MCP server state file against malformed JSON shape

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -25,10 +25,13 @@ function loadState(): McpState {
   try {
     if (fs.existsSync(STATE_FILE)) {
       const raw = fs.readFileSync(STATE_FILE, 'utf-8');
-      return JSON.parse(raw) as McpState;
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as McpState;
+      }
     }
   } catch {
-    // Ignore read errors; treat as empty state
+    // Ignore read/parse errors; treat as empty state
   }
   return {};
 }


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked at start of this routine run:
- #72 `dependabot/npm_and_yarn/npm_and_yarn-152536bbd4` — touches `package.json`, `package-lock.json`
- #71 `routine/qp-fix-version-diff-provider-reregister-260802` — touches `src/commands/versionCommands.ts`
- #70 `routine/qp-fix-i18n-path-leak-260801` — touches `src/i18n.ts`
- #69 `routine/qp-fix-secretstorage-tokenmap-shape-260731` — touches `src/privacy/masking/secretStorage.ts`, `src/test/unit/secretStorage.test.ts`
- #68 `routine/qp-fix-hover-tooltip-command-trust-260730` — touches `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts`
- #67 `routine/qp-fix-promptprovider-path-leak-260728` — touches `src/promptProvider.ts`
- #66 `routine/qp-fix-privacy-dictionary-shape-260727` — touches `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts`

This PR only touches `mcp-server/src/index.ts`, which is not referenced by any of the above. No overlap.

## Changes

`mcp-server/src/index.ts`'s `loadState()` read `~/.quickprompt-mcp-state.json` and did `JSON.parse(raw) as McpState` with no shape check. `JSON.parse` succeeds for any valid JSON value — `null`, a bare string, a number, an array — not just an `McpState`-shaped object. If the cache file were ever corrupted or manually edited to contain e.g. `null`, `state.lastWorkspaceRoot` in `main()` would throw `TypeError: Cannot read properties of null`, which propagates out of `main()`'s try/catch and calls `process.exit(1)` — the server would fail to start entirely, defeating the existing comment's intent ("Ignore read errors; treat as empty state").

Fix: after `JSON.parse`, verify the parsed value is a non-null, non-array object before treating it as `McpState`; otherwise fall back to `{}` exactly as the missing-file and parse-error paths already do.

This PR does not modify any MCP tool schema, name, or parameter (nothing under `mcp-server/src/tools/` was touched), and does not add/remove/update any dependency.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` — 9 suites / 119 tests passed
- `npm run test:coverage` (matches CI's test command) — 9 suites / 119 tests passed

No lint or format:check script exists in this repo's package.json, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.