### PR TITLE
[Routine - QP] fix: avoid logging full clipboard history file path on read/write errors

### DIFF
--- a/src/ClipboardManager.ts
+++ b/src/ClipboardManager.ts
@@ -3,6 +3,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { CLIPBOARD_CONSTANTS } from './utils/constants';
+
+/**
+ * 將檔案系統錯誤格式化為安全的日誌訊息：僅保留錯誤代碼，避免將
+ * fs.readFile/writeFile 等錯誤訊息中內嵌的完整檔案路徑（含使用者主目錄）寫入日誌。
+ */
+function formatFsErrorForLog(error: unknown): string {
+    const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+    return code ?? (error instanceof Error ? error.name : 'unknown error');
+}
+
 export interface ClipboardHistoryItem {
     id: string;              // 唯一識別碼
     content: string;         // 剪貼簿內容
@@ -326,7 +336,7 @@ export class ClipboardManager {
                 const parsed: unknown = JSON.parse(data);
                 this.history = Array.isArray(parsed) ? parsed : [];
             } catch (err) {
-                console.error('Failed to parse clipboard history file:', err);
+                console.error(`Failed to parse clipboard history file: ${formatFsErrorForLog(err)}`);
                 this.history = [];
             }
         } else {
@@ -351,7 +361,7 @@ export class ClipboardManager {
             this.storagePath,
             JSON.stringify(this.history, null, 2),
             'utf-8'
-        ).catch(err => console.error('Failed to save clipboard history file:', err));
+        ).catch(err => console.error(`Failed to save clipboard history file: ${formatFsErrorForLog(err)}`));
     }
 
     /**


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs checked (all draft/routine + 1 dependabot):

| PR | Files touched |
|----|----|
| #73 | `mcp-server/src/index.ts` |
| #71 | `src/commands/versionCommands.ts` |
| #70 | `src/i18n.ts` |
| #69 | `src/privacy/masking/secretStorage.ts`, `src/test/unit/secretStorage.test.ts` |
| #68 | `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts` |
| #67 | `src/promptProvider.ts` |
| #66 | `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts` |
| #72 | `package.json`/`package-lock.json` (dependabot, deps only) |

Also checked stale remote branches referencing clipboard code (`routine/qp-fix-corrupted-clipboard-json-260626`, `routine/qp-fix-mcp-clipboard-non-array-260706`, `routine/qp-fix-clipboard-window-listener-leak-260715`) by diffing their content against current `master` — they predate the already-merged `windowStateListener` disposal fix (PR #54) and contain no pending changes relevant to this fix.

This PR touches only `src/ClipboardManager.ts`, specifically the `loadHistory()`/`saveHistory()` error-logging paths, which none of the above PRs or branches modify. No overlap.

## 2. Changes

`ClipboardManager.loadHistory()`/`saveHistory()` interpolated the raw `fs` error object into `console.error(...)` on JSON-parse or file I/O failure. Node fs errors (e.g. `ENOENT`, `EACCES`) embed the full absolute path in `error.message`, which includes the user's home directory name (`~/.quickprompt/clipboard-history.json`). Added a local `formatFsErrorForLog()` helper (mirroring the same pattern already used in `src/promptProvider.ts`) that keeps only the error code, and applied it at both log sites.

- Does not modify any MCP tool schema, name, or parameters in `mcp-server/src/tools/`.
- Does not add, remove, or update any dependency.
- Does not modify `package.json`/`package-lock.json`.

## 3. Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./              # clean, no errors
npm run test:coverage      # 9 suites / 119 tests passed
```

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.