### PR TITLE
[Routine - QP] fix: avoid leaking full clipboard history file path via MCP tool error

### DIFF
--- a/mcp-server/src/tools/clipboardTools.ts
+++ b/mcp-server/src/tools/clipboardTools.ts
@@ -6,12 +6,21 @@ import { ErrorType } from '../types.js';
 import { createSuccess, createError } from '../utils/ResponseFactory.js';
 
 export interface ClipboardHistoryItem {
-    id: string;              
-    content: string;         
-    preview: string;         
-    timestamp: number;       
-    source: 'vscode' | 'external';  
-    length: number;          
+    id: string;
+    content: string;
+    preview: string;
+    timestamp: number;
+    source: 'vscode' | 'external';
+    length: number;
+}
+
+/**
+ * 將檔案系統錯誤格式化為安全的訊息：僅保留錯誤代碼，避免將
+ * fs.readFileSync 錯誤訊息中內嵌的完整檔案路徑（含使用者主目錄）回傳給呼叫端。
+ */
+function formatFsErrorForLog(error: unknown): string {
+  const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+  return code ?? (error instanceof Error ? error.name : 'unknown error');
 }
 
 export class ClipboardTools {
@@ -27,7 +36,7 @@ export class ClipboardTools {
         const parsed: unknown = JSON.parse(data);
         return Array.isArray(parsed) ? (parsed as ClipboardHistoryItem[]) : [];
       } catch (err) {
-        throw new Error(`Failed to read clipboard history: ${err}`);
+        throw new Error(`Failed to read clipboard history: ${formatFsErrorForLog(err)}`);
       }
     }
     return [];


### PR DESCRIPTION
## Pre-flight Check

Open PRs at time of this routine run (all `[Routine - QP]` drafts unless noted):

| PR | Branch | Files touched |
|----|--------|----------------|
| #74 | routine/qp-fix-clipboard-history-path-leak-260806 | `src/ClipboardManager.ts` |
| #73 | routine/qp-fix-mcp-state-shape-guard-260804 | `mcp-server/src/index.ts` |
| #72 | dependabot/npm_and_yarn/... | (dependency bump, not routine) |
| #71 | routine/qp-fix-version-diff-provider-reregister-260802 | `src/commands/versionCommands.ts` |
| #70 | routine/qp-fix-i18n-path-leak-260801 | `src/i18n.ts` |
| #69 | routine/qp-fix-secretstorage-tokenmap-shape-260731 | `src/privacy/masking/secretStorage.ts`, its test |
| #68 | routine/qp-fix-hover-tooltip-command-trust-260730 | `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts` |
| #67 | routine/qp-fix-promptprovider-path-leak-260728 | `src/promptProvider.ts` |
| #66 | routine/qp-fix-privacy-dictionary-shape-260727 | `src/core/PrivacyManager.ts`, its test |

Also reviewed `git branch -r` for older `routine/*` branches without an open PR (e.g. `backup-log-path-leak`, `debug-log-path-leak`, `mcp-workspace-path-leak`, `substr-deprecation`, etc.) — none touch `mcp-server/src/tools/clipboardTools.ts`, and their commit subjects (matched against `git log`) indicate they're already merged into `master`.

This PR touches only `mcp-server/src/tools/clipboardTools.ts`, which is not modified by any of the above — no overlap.

## Changes

`ClipboardTools.loadHistory()` (used by the MCP `get_clipboard_item` tool) caught `fs.readFileSync` errors and re-threw them as `` `Failed to read clipboard history: ${err}` ``. That interpolation embeds the raw Node.js error, which for common failures (e.g. `ENOENT`) includes the full absolute file path under the user's home directory. The re-thrown error's `.message` is then surfaced verbatim as the MCP tool's error response text in `getClipboardItem()`'s catch block — leaking the user's home directory path to whatever MCP client/LLM is calling the tool.

Fixed by adding a small `formatFsErrorForLog()` helper that reduces the error down to just its `code` (e.g. `ENOENT`) or `name`, mirroring the identical helper already introduced in `src/ClipboardManager.ts` by PR #74 for the same class of issue.

Confirms this PR does not modify any MCP tool schema, name, or parameter (only internal error-formatting logic in `clipboardTools.ts`), and does not add/remove/update any dependency.

## Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./
npm run test
```

- `tsc`: no errors.
- `npm run test`: 9 suites / 119 tests passed.

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine's conditional instructions.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.