### PR TITLE
[Routine - QP] fix: dispose MaskingEngine config-change listener via context.subscriptions

### DIFF
--- a/src/privacy/maskingEngine.ts
+++ b/src/privacy/maskingEngine.ts
@@ -22,12 +22,14 @@ export class MaskingEngine {
         this.registry.loadBuiltIn(PREDEFINED_PATTERNS);
         this.registry.applyConfig(this.config);
 
-        vscode.workspace.onDidChangeConfiguration(e => {
-            if (e.affectsConfiguration('quickPrompt.privacy')) {
-                this.config = this.loadConfig();
-                this.registry.applyConfig(this.config);
-            }
-        });
+        context.subscriptions.push(
+            vscode.workspace.onDidChangeConfiguration(e => {
+                if (e.affectsConfiguration('quickPrompt.privacy')) {
+                    this.config = this.loadConfig();
+                    this.registry.applyConfig(this.config);
+                }
+            })
+        );
     }
 
     public static getInstance(context?: vscode.ExtensionContext): MaskingEngine {

--- a/src/test/unit/maskingEngine.test.ts
+++ b/src/test/unit/maskingEngine.test.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+import { MaskingEngine } from '../../privacy/maskingEngine';
+
+describe('MaskingEngine', () => {
+    it('registers its config-change listener as a disposable subscription', () => {
+        const spy = jest.spyOn(vscode.workspace, 'onDidChangeConfiguration');
+        const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+        MaskingEngine.getInstance(context);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        const disposable = spy.mock.results[0].value;
+        expect(context.subscriptions).toContain(disposable);
+    });
+});


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs at time of this run (all Draft, `CLEAN` merge state):

| # | Title | Files touched |
|---|---|---|
| 75 | avoid leaking full clipboard history file path via MCP tool error | `mcp-server/src/tools/clipboardTools.ts` |
| 74 | avoid logging full clipboard history file path on read/write errors | `src/ClipboardManager.ts` |
| 73 | guard MCP server state file against malformed JSON shape | `mcp-server/src/index.ts` |
| 72 | chore(deps): bump npm_and_yarn group | (dependabot, non-code) |
| 71 | dispose previous version-diff content provider before re-registering | `src/commands/versionCommands.ts` |
| 70 | avoid logging raw error object on i18n language file load failure | `src/i18n.ts` |
| 69 | guard SecretStorageManager against malformed token map shape | `src/privacy/masking/secretStorage.ts` |
| 68 | disable command-link trust on hover/tooltip MarkdownStrings | `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts` |
| 67 | avoid logging full workspace path in PromptProvider catch blocks | `src/promptProvider.ts` |
| 66 | guard PrivacyManager dictionary load against malformed JSON shape | `src/core/PrivacyManager.ts` |

This PR touches only `src/privacy/maskingEngine.ts` and adds a new test file `src/test/unit/maskingEngine.test.ts` — no overlap with any file listed above, and no duplicate fix for an already-open PR.

Recent branch names (`git branch -r`) were also checked; no other in-flight `routine/qp-fix-*` branch targets `maskingEngine.ts`.

## 2. Changes

`MaskingEngine`'s private constructor registered a `vscode.workspace.onDidChangeConfiguration` listener but discarded the returned `Disposable` instead of keeping it, so the listener could never be cleaned up when the extension deactivates. Since the constructor already receives `context: vscode.ExtensionContext`, the fix routes the listener through `context.subscriptions.push(...)`, matching the disposal pattern already used elsewhere in the codebase (e.g. the AI-settings listener in `extension.ts`).

- Modified: `src/privacy/maskingEngine.ts` (2-line change — wrap the existing listener registration in `context.subscriptions.push(...)`)
- Added: `src/test/unit/maskingEngine.test.ts` — asserts the listener's `Disposable` is present in `context.subscriptions` after `MaskingEngine.getInstance(context)`.

Confirms:
- No MCP tool schema, name, or parameter changes (`mcp-server/src/tools/` untouched).
- No dependency changes (`package.json` / `package-lock.json` untouched).

## 3. Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./
# no output — type-check clean

npm run test
# Test Suites: 10 passed, 10 total
# Tests:       120 passed, 120 total
```

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the project's available scripts.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI's version-bump/release gate fails on this PR for that reason, that is expected release-readiness behavior, not a code validation failure.