### PR TITLE
[Routine - QP] fix: fail fast on worker summarize error instead of 90s timeout

### DIFF
--- a/src/ai/aiEngine.ts
+++ b/src/ai/aiEngine.ts
@@ -222,7 +222,16 @@ export class AIEngine {
             }
             case 'error':
                 console.error('[AIEngine] Worker reported error:', message.error);
-                this.status = 'error';
+                if (message.requestId !== undefined && this.pendingRequests.has(message.requestId)) {
+                    // Request-scoped failure (e.g. summarize()) — fail fast instead of
+                    // waiting for the 90s timeout in summarizeViaWorker(), and don't mark
+                    // the whole engine as broken over a single bad generation.
+                    const req = this.pendingRequests.get(message.requestId)!;
+                    this.pendingRequests.delete(message.requestId);
+                    req.reject(new Error(message.error));
+                } else {
+                    this.status = 'error';
+                }
                 break;
         }
     }

--- a/src/ai/aiWorker.ts
+++ b/src/ai/aiWorker.ts
@@ -33,7 +33,8 @@ parentPort.on('message', async (message: any) => {
     } catch (error: any) {
         parentPort?.postMessage({
             type: 'error',
-            error: error.message || String(error)
+            error: error.message || String(error),
+            ...(message.requestId !== undefined && { requestId: message.requestId })
         });
     }
 });


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (files touched, none overlap with this change):
- #76 `src/privacy/maskingEngine.ts`, `src/test/unit/maskingEngine.test.ts`
- #75 `mcp-server/src/tools/clipboardTools.ts`
- #74 `src/ClipboardManager.ts`
- #73 `mcp-server/src/index.ts`
- #72 `package.json`, `package-lock.json` (dependabot)
- #71 `src/commands/versionCommands.ts`
- #70 `src/i18n.ts`
- #69 `src/privacy/masking/secretStorage.ts`, `src/test/unit/secretStorage.test.ts`
- #68 `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts`
- #67 `src/promptProvider.ts`
- #66 `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts`

Also reviewed all `routine/qp-fix-*` remote branches without an open PR (mostly merged already, e.g. `qp-fix-debug-log-path-leak-260710` → merged in #51, or long-abandoned, e.g. `qp-fix-ai-progress-cleanup-260629` → closed #39 without merging).

This PR touches only `src/ai/aiEngine.ts` and `src/ai/aiWorker.ts`, in a code path (worker `error` message → per-request rejection) not touched by any of the above. It does not overlap with the previously merged/closed AI-engine PRs either (those addressed path-logging and `withProgress`/loadingProgress cleanup, both unrelated call sites).

## Changes

`AIEngine.summarizeViaWorker()` sets a 90s timeout per request and falls back to a local title if the worker never replies. However, when the worker thread (`aiWorker.ts`) actively reported an `error` message (e.g. a generation failure), it never carried the originating `requestId`, so `AIEngine.handleWorkerMessage()` had no way to resolve that specific pending request — it just flipped the whole engine status to `'error'` and left the caller waiting the full 90 seconds before falling back.

- `src/ai/aiWorker.ts`: the outer message-handler catch now echoes `requestId` (when present) alongside the error.
- `src/ai/aiEngine.ts`: `handleWorkerMessage`'s `'error'` case now looks up the pending request by `requestId` and resolves it immediately via the existing fallback path, instead of leaving it to the timeout. Errors without a `requestId` (i.e. worker init failures) keep the previous behavior of flipping engine status to `'error'`.

Confirms: this PR does not modify any MCP tool schema/name/parameter in `mcp-server/src/tools/`, and does not add/remove/update any dependency.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (Jest, `--runInBand`) — 9 suites / 119 tests passed

(No `lint` or `format:check` script exists in `package.json`, so those were skipped.)

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.