### PR TITLE
[Routine - QP] fix: dispose clipboardHistoryView tree data provider registration

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,7 +159,9 @@ function initializeProviders(context: vscode.ExtensionContext, versionHistorySer
     // 初始化 ClipboardProvider (新的獨立剪貼簿視圖)
     const clipboardProvider = new ClipboardProvider();
     clipboardProvider.setClipboardManager(clipboardManager);
-    vscode.window.registerTreeDataProvider('clipboardHistoryView', clipboardProvider);
+    context.subscriptions.push(
+        vscode.window.registerTreeDataProvider('clipboardHistoryView', clipboardProvider)
+    );
 
     // 註冊即時捕捉（監聽選取變化）
     clipboardManager.registerInstantCapture(context.subscriptions);


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs checked (11 open, all draft `[Routine - QP]` fixes + 1 dependabot):

| PR | Files touched |
|----|----|
| #77 | src/ai/aiEngine.ts, src/ai/aiWorker.ts |
| #76 | src/privacy/maskingEngine.ts, src/test/unit/maskingEngine.test.ts |
| #75 | mcp-server/src/tools/clipboardTools.ts |
| #74 | src/ClipboardManager.ts |
| #73 | mcp-server/src/index.ts |
| #72 (dependabot) | package.json / package-lock.json |
| #71 | src/commands/versionCommands.ts |
| #70 | src/i18n.ts |
| #69 | src/privacy/masking/secretStorage.ts, src/test/unit/secretStorage.test.ts |
| #68 | src/promptHoverProvider.ts, src/treeItems/VersionItem.ts |
| #67 | src/promptProvider.ts |
| #66 | src/core/PrivacyManager.ts, src/test/unit/privacyManager.test.ts |

Also reviewed the last 10 commits on `master` (path-leak logging fixes, JSON shape guards, listener-disposal fixes, `PatternRegistry.mask` offset fix, jest config fix) to avoid re-fixing already-landed issues.

This PR touches only `src/extension.ts`, which is not modified by any open PR or recent commit, so there is no overlap.

## 2. Changes

`initializeProviders()` in `src/extension.ts` registers the `clipboardHistoryView` tree data provider via `vscode.window.registerTreeDataProvider(...)` but discarded the returned `Disposable` instead of pushing it to `context.subscriptions`, unlike every other registration in the same function (`promptTreeView`, file system provider, hover provider). This means the registration is never cleaned up on extension deactivation/reload — the same category of bug already fixed elsewhere in this repo (config-change listener in `maskingEngine.ts`, window focus listener in `ClipboardManager.ts`, content provider re-registration in `versionCommands.ts`), just a previously-missed instance in a different file.

Fix: wrap the registration call in `context.subscriptions.push(...)`, matching the existing pattern used two lines above it in the same function.

This PR does **not** modify any MCP tool schema/name/parameters in `mcp-server/src/tools/`, and does not add/remove/update any dependency.

## 3. Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./
```
→ no errors.

```
npm run test:coverage
```
→ 9 test suites, 119 tests, all passed. Coverage table printed with no threshold failures.

(No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine's own script-detection rule.)

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR — not part of this PR's scope.

If CI fails solely due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.