### PR TITLE
[Routine - QP] fix: escape workspace name/id in MCP config webview HTML

### DIFF
--- a/src/mcp/McpConfigPanel.ts
+++ b/src/mcp/McpConfigPanel.ts
@@ -29,6 +29,15 @@ interface WorkspaceOption {
     path: string;
 }
 
+export function escapeHtmlForWebview(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 export class McpConfigPanel {
     public static currentPanel: McpConfigPanel | undefined;
     private readonly _panel: vscode.WebviewPanel;
@@ -236,7 +245,7 @@ export class McpConfigPanel {
         const workspaceOptionsHtml = workspaceContext.workspaces.length > 0
             ? workspaceContext.workspaces.map(workspace => {
                 const selected = workspace.id === workspaceContext.selectedWorkspaceId ? 'selected' : '';
-                return `<option value="${workspace.id}" ${selected}>${workspace.name}</option>`;
+                return `<option value="${escapeHtmlForWebview(workspace.id)}" ${selected}>${escapeHtmlForWebview(workspace.name)}</option>`;
             }).join('')
             : `<option value="__none__">${i18n.workspaceEmpty}</option>`;
 

--- a/src/test/unit/mcpConfigPanel.test.ts
+++ b/src/test/unit/mcpConfigPanel.test.ts
@@ -1,0 +1,19 @@
+import { escapeHtmlForWebview } from '../../mcp/McpConfigPanel'
+
+describe('escapeHtmlForWebview', () => {
+    it('escapes HTML special characters', () => {
+        expect(escapeHtmlForWebview('<img src=x onerror=alert(1)>')).toBe(
+            '&lt;img src=x onerror=alert(1)&gt;'
+        )
+    })
+
+    it('escapes ampersands, quotes and apostrophes', () => {
+        expect(escapeHtmlForWebview(`Tom & "Jerry" 'Show'`)).toBe(
+            'Tom &amp; &quot;Jerry&quot; &#39;Show&#39;'
+        )
+    })
+
+    it('leaves plain text untouched', () => {
+        expect(escapeHtmlForWebview('my-workspace_01')).toBe('my-workspace_01')
+    })
+})


### PR DESCRIPTION
## 1. Pre-flight Check

Checked open PRs (#66–#78) and active `routine/*` branches before selecting a target. Touched files across open PRs at time of this run:

- `src/core/PrivacyManager.ts`, `src/test/unit/privacyManager.test.ts` (#66)
- `src/promptProvider.ts` (#67)
- `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts` (#68)
- `src/privacy/masking/secretStorage.ts`, `src/test/unit/secretStorage.test.ts` (#69)
- `src/i18n.ts` (#70)
- `src/commands/versionCommands.ts` (#71)
- `package.json`, `package-lock.json` (#72, dependabot)
- `mcp-server/src/index.ts` (#73)
- `src/ClipboardManager.ts` (#74)
- `mcp-server/src/tools/clipboardTools.ts` (#75)
- `src/privacy/maskingEngine.ts`, `src/test/unit/maskingEngine.test.ts` (#76)
- `src/ai/aiEngine.ts`, `src/ai/aiWorker.ts` (#77)
- `src/extension.ts` (#78)

This PR only touches `src/mcp/McpConfigPanel.ts` (new fix) and adds `src/test/unit/mcpConfigPanel.test.ts` (new test file) — no overlap with any file above, and no active `routine/*` branch without a PR was targeting this file either.

## 2. Changes

`McpConfigPanel._getHtmlForWebview` builds the workspace `<select>` options by interpolating `workspace.id` / `workspace.name` (the on-disk workspace folder name, via `folder.name`) directly into an HTML string. The panel is created with `enableScripts: true` and no Content-Security-Policy, so a workspace folder whose name contains HTML/script content would be injected unescaped into the webview markup.

Fix: extracted a small `escapeHtmlForWebview()` helper and applied it to both interpolated values before they're placed into the `<option>` tag.

Confirms this PR does **not** modify any MCP tool schema/name/parameter in `mcp-server/src/tools/`, and does **not** add/remove/update any dependency.

## 3. Safety Verification

Commands run locally, all passed:

- `npx tsc -p ./` — no errors
- `npm run test:coverage` — 10 suites, 122 tests passed (includes the new `mcpConfigPanel.test.ts`, 3 tests)

No `lint` or `format:check` npm script exists in this repo, so those steps were skipped per the project's actual script set.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.