### PR TITLE
[Routine - QP] fix: avoid logging raw fs error object on version history save failure

### DIFF
--- a/src/services/VersionHistoryService.ts
+++ b/src/services/VersionHistoryService.ts
@@ -9,6 +9,15 @@ export interface VersionHistoryLocation {
 }
 
 /**
+ * 將檔案系統錯誤格式化為安全的日誌訊息：僅保留錯誤代碼，避免將
+ * vscode.workspace.fs 寫入失敗訊息中內嵌的完整檔案路徑寫入日誌。
+ */
+function formatFsErrorForLog(error: unknown): string {
+    const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+    return code ?? (error instanceof Error ? error.name : 'unknown error');
+}
+
+/**
  * Service for managing prompt version history
  * 
  * This service handles all version-related operations including:
@@ -135,7 +144,7 @@ export class VersionHistoryService {
             // Update cache
             this.cache.set(location.cacheKey, history);
         } catch (error) {
-            console.error(`Failed to save version history for ${history.promptId}:`, error);
+            console.error(`Failed to save version history for ${history.promptId}: ${formatFsErrorForLog(error)}`);
             throw error;
         }
     }


### PR DESCRIPTION
## Pre-flight Check

**Open PRs checked (Phase 1):** #79, #78, #77, #76, #75, #74, #73, #72, #71, #70, #69, #68, #67, #66 — all Draft `[Routine - QP]` fixes (or dependabot #72), touching:
`src/mcp/McpConfigPanel.ts`, `src/extension.ts`, `src/ai/aiEngine.ts`, `src/ai/aiWorker.ts`, `src/privacy/maskingEngine.ts`, `mcp-server/src/tools/clipboardTools.ts`, `src/ClipboardManager.ts`, `mcp-server/src/index.ts`, `package.json`/`package-lock.json`, `src/commands/versionCommands.ts`, `src/i18n.ts`, `src/privacy/masking/secretStorage.ts`, `src/promptHoverProvider.ts`, `src/treeItems/VersionItem.ts`, `src/promptProvider.ts`, `src/core/PrivacyManager.ts`.

**Active branches:** the many `routine/qp-fix-*` and `release/*` remote branches listed above, plus `dependabot/npm_and_yarn/...` and `copilot/support-local-ml-pii-detection`.

**No overlap:** This PR touches only `src/services/VersionHistoryService.ts`, which is not modified by any open PR or active branch. It follows the same `formatFsErrorForLog` pattern already merged/proposed for `ClipboardManager.ts` (#74) and `promptProvider.ts` (#67), but applied to a different, previously-unaddressed file.

## Changes

`VersionHistoryService.saveHistory()` caught write failures from `vscode.workspace.fs.writeFile` and logged the raw `error` object via `console.error`. Node/VS Code fs errors typically embed the absolute file path (including the user's home directory) in `error.message`, e.g. `ENOENT: no such file or directory, open 'C:\Users\<name>\...\history\<id>.history.json'`.

Added a local `formatFsErrorForLog()` helper (same shape as the ones already in `ClipboardManager.ts` / `promptProvider.ts`) that logs only the error code or name, and used it in the one `console.error` call in this file that logged a raw fs error. The other two `console.error` calls in this file (invalid history shape, JSON `SyntaxError`) do not carry a file path and were left unchanged.

- Confirms this PR does **not** modify any MCP tool schema (`mcp-server/src/tools/`), does **not** add/remove/update any dependency, and does **not** touch `package.json` / `package-lock.json` / `CHANGELOG.md`.

## Safety Verification

Commands run locally (Windows / PowerShell+Bash), all passed:

```bash
npx tsc -p ./
npx jest --runInBand src/test/unit/versionHistoryService.test.ts
npm run test:coverage
```

- `tsc`: no errors.
- Targeted test file: 4/4 passed.
- Full suite: **9 test suites passed, 119 tests passed, 0 failed.**

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.