### PR TITLE
fix: PrivacyManager substring-label unmask corruption (#63) + fill test gaps

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -3,14 +3,11 @@
 [繁體中文](./TESTING.zh-TW.md) | English
 
 This is the current, maintained reference for this repo's **automated** test
-suites. It replaces the older manual-testing checklists under `docs/specs/`
-(`TESTING_GUIDE.md`, `MCP_CRUD_TEST_CASES.md`, `MCP_E2E_TESTING_GUIDE.md`,
-`PRIVACY_TEST_GUIDE.md`, `20260408_manual_test.md`), which describe a
-v0.3.0-era feature set (e.g. an interactive Privacy Dictionary UI) that no
-longer exists in the current extension — the dictionary feature was removed
-in v2 in favor of settings-based custom rules (see `src/privacy/maskingEngine.ts`).
-Those files are kept for historical reference only; do not use them to judge
-current behavior or coverage.
+suites. Note for context: `PrivacyManager`'s dictionary feature (see the unit
+test table below) predates a v2 rewrite that replaced it with settings-based
+custom rules (`src/privacy/maskingEngine.ts`) — if you find older local notes
+describing an interactive Privacy Dictionary UI, that feature no longer
+exists; don't use such notes to judge current behavior or coverage.
 
 If you add, rename, or remove a test file, update this doc in the same PR.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,5 +1,7 @@
 # Testing Guide (Quick Prompt)
 
+[繁體中文](./TESTING.zh-TW.md) | English
+
 This is the current, maintained reference for this repo's **automated** test
 suites. It replaces the older manual-testing checklists under `docs/specs/`
 (`TESTING_GUIDE.md`, `MCP_CRUD_TEST_CASES.md`, `MCP_E2E_TESTING_GUIDE.md`,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,91 @@
+# Testing Guide (Quick Prompt)
+
+This is the current, maintained reference for this repo's **automated** test
+suites. It replaces the older manual-testing checklists under `docs/specs/`
+(`TESTING_GUIDE.md`, `MCP_CRUD_TEST_CASES.md`, `MCP_E2E_TESTING_GUIDE.md`,
+`PRIVACY_TEST_GUIDE.md`, `20260408_manual_test.md`), which describe a
+v0.3.0-era feature set (e.g. an interactive Privacy Dictionary UI) that no
+longer exists in the current extension — the dictionary feature was removed
+in v2 in favor of settings-based custom rules (see `src/privacy/maskingEngine.ts`).
+Those files are kept for historical reference only; do not use them to judge
+current behavior or coverage.
+
+If you add, rename, or remove a test file, update this doc in the same PR.
+
+## Running the tests
+
+| Suite | Command | What it covers |
+|---|---|---|
+| Root unit tests | `npm test` | Pure Node/Jest tests for the extension host code, mocking `vscode` via `src/test/__mocks__/vscode.ts` |
+| mcp-server unit tests | `cd mcp-server && npm test` | Isolated Jest config (`mcp-server/jest.config.cjs`) for the MCP server package, which has different module/tsconfig settings than the root and can't share the root's ts-jest config |
+| UI / E2E tests | `npm run test:ui` | Real VS Code + Selenium (`vscode-extension-tester`) driving the packaged extension end to end |
+
+**UI tests require a real, visible VS Code window and take several minutes.**
+They should be run by a human on their own machine, not by an AI agent in a
+sandboxed environment — see "Known limitations" below for why.
+
+The mcp-server suite is *not* part of the root `npm test` run (its `src/test/`
+files match the root Jest config's `testMatch` glob and happen to also pass
+under the root's `ts-jest` config today, but it has its own dedicated config
+and script specifically so it isn't required to keep working that way).
+
+## Root unit tests (`src/test/unit/`)
+
+| File | Covers |
+|---|---|
+| `promptManager.test.ts` | `PromptManager` CRUD: load/save prompts.json, corrupted/non-array JSON recovery, create/update/delete/pin/reorder/increment-use, optimistic locking (`OptimisticLockError`), cache invalidation |
+| `versionManager.test.ts` | `VersionManager`: version history CRUD, corrupted/wrong-shape JSON recovery, dedup on unchanged content, milestones, `MAX_VERSIONS` pruning (protects milestones), cache clearing, path-traversal rejection |
+| `versionHistoryService.test.ts` | `VersionHistoryService`: load/reset on corrupted or wrong-shape history, fs-error logging doesn't leak the raw error/path but still rethrows |
+| `versionCommands.test.ts` | **PR #71** — `handleShowVersionDiff` disposes its previous `TextDocumentContentProvider` registration before creating the next one, and viewing two diffs back to back never throws |
+| `versionItem.test.ts` | **PR #68** (security) — `VersionItem`'s tooltip `MarkdownString` has `isTrusted` falsy, even for a milestone label crafted as a `command:` link |
+| `promptHoverProvider.test.ts` | **PR #68** (security) — same `isTrusted` property, for `PromptHoverProvider`'s hover `MarkdownString` built from a prompt title |
+| `promptProviderFsErrorLogging.test.ts` | **PR #67** — `PromptProvider.savePrompts()` logs only the fs error code on failure, never the full workspace path |
+| `promptProviderMultiroot.test.ts` | `PromptProvider` routing in multi-root workspaces: version history stored in the correct workspace, doesn't overwrite a workspace that failed to load, scope switching, quick-create target resolution |
+| `multiroot.test.ts` | Multi-root support at the `PromptManager`/MCP-tool level: workspace-prefixed IDs, routing validation, primary-workspace fallback |
+| `clipboardManager.test.ts` | `ClipboardManager`: duplicate/short/numeric-content filtering, corrupted history JSON recovery, **PR #74** fs-error path-leak fix, focus-listener disposal |
+| `secretStorage.test.ts` | `SecretStorageManager`: round-trip, and **PR #69** guard against a malformed/non-object/non-string token map (returns `undefined` instead of corrupting output) |
+| `privacyManager.test.ts` | `PrivacyManager`: repeated-value unmasking, **issue #63** — restores longer masked values before a shorter one that's their literal prefix (regardless of dictionary-insertion order), and **PR #66** malformed `privacy-dictionary.json` shape guard. Note: this class's dictionary feature is only reachable from the standalone `qp.bundle.js` CLI (the `quickprompt` skill), not the VS Code extension UI — the fix is correct but doesn't affect any current VS Code UI user |
+| `maskingEngine.test.ts` | `MaskingEngine` registers its config-change listener as a disposable (resource-leak guard) |
+| `mcpConfigPanel.test.ts` | **PR #79** (security) — `escapeHtmlForWebview()` correctly escapes `&<>"'`, used to sanitize workspace names before they're interpolated into the MCP config webview's HTML |
+| `i18n.test.ts` | `I18n`: doesn't throw on a missing/failing locale file, falls back to English, and **PR #70** doesn't log the raw error object, only the locale code |
+| `pathUtils.test.ts` | `PathUtils`: workspace-containment validation (including path-traversal and sibling-prefix attacks), path resolution/relativization, directory creation, JSON read/write, mtime lookup |
+| `patternRegistry.test.ts` | `PatternRegistry.mask()`: repeated-match masking when label length differs from match length, 3+ occurrences of the same pattern |
+| `aiEngine.test.ts` | **PR #77** — `AIEngine.handleWorkerMessage` rejects the specific pending request immediately on a worker error (by `requestId`), doesn't affect other concurrently pending requests, and falls back to the pre-fix global-status behavior when a message has no `requestId` |
+
+## mcp-server unit tests (`mcp-server/src/test/`)
+
+| File | Covers |
+|---|---|
+| `stateStore.test.ts` | **PR #73** — `loadState()`/`saveState()` (the `~/.quickprompt-mcp-state.json` persisted state) guard against `null`/array/number/invalid-JSON shapes, falling back to `{}` instead of crashing the whole MCP server process |
+| `clipboardTools.test.ts` | **PR #75** — the clipboard MCP tool doesn't leak the clipboard-history file's absolute path in an fs-error response |
+
+## UI / E2E tests (`src/test/ui/`)
+
+Each file opens its own temp workspace (or its own `.code-workspace` fixture)
+via `VSBrowser.instance.openResources(...)` in a `before()` hook — they don't
+share state with each other, though they do all run in the *same* VS Code/
+Chromium process within one `npm run test:ui` invocation (mocha runs them
+sequentially as separate `describe` blocks against sequentially-opened
+workspaces).
+
+| File | Covers |
+|---|---|
+| `quickPrompt.ui.test.ts` | The core interactive flows: sidebar renders, command palette exposes the primary commands, search + copy + use-count increment, opening a prompt from the tree and editing it, Add Prompt (Auto Title / Custom Title), Quick Add from selection, Show MCP Config, Refresh Clipboard History |
+| `multiRootQuickPrompt.ui.test.ts` | Multi-root workspace behavior through the real UI: flat prompt list for the default scope, scoped search, Quick Add targeting the active editor's workspace root |
+| `securityFixes.ui.test.ts` | **PR #79** (security) — opens a real multi-root workspace with a maliciously-named folder, runs "Show MCP Config", and inspects the actual webview DOM to confirm the payload renders as inert text and never executes. (**PR #68's hover E2E test was removed** — see "Known limitations" below; that fix's coverage lives entirely in the unit tests) |
+| `versionDiff.ui.test.ts` | **PR #71** — clicks through 3 version-history rows back-to-back via real tree interaction, confirms each diff renders correctly with no "failed to show version diff" notification |
+| `malformedConfigResilience.ui.test.ts` | **PR #66** — corrupts `.vscode/privacy-dictionary.json` *before* opening the workspace, confirms the extension still activates, the sidebar renders, and adding a prompt still works. (Does **not** exercise `PrivacyManager`'s guard clause itself, since that class isn't wired into the extension UI — only proves the extension doesn't crash) |
+| `aiTitleGeneration.ui.test.ts` | **PR #77**, narrower scope — points the AI provider at an unreachable endpoint and confirms "Add Prompt (Auto Title)" still persists a fallback title within seconds (not the 90s worker timeout) and the extension host stays responsive afterward. Does not reproduce the exact `requestId`-rejection code path (see unit test), since triggering a *real* local-model worker error requires an actual model download and has no UI-observable signature anyway — the background title-generation call is fire-and-forget |
+
+### Investigated but not written (documented reasoning inline in the relevant test file or PR)
+
+- **Issue #63** (`PrivacyManager` substring-label unmasking): not E2E-testable — the class isn't reachable from any VS Code command or UI action.
+- **PR #69** (`SecretStorageManager` malformed token map): not E2E-testable — the token map lives only in the OS keychain via VS Code's `SecretStorage` API, never as an on-disk artifact that a test could corrupt from outside the process.
+- **PR #78** (`clipboardHistoryView` tree provider disposal): the only way to observe a real disposal failure is a full extension deactivate/reactivate cycle (e.g. "Developer: Reload Window"), and `vscode-extension-tester`'s WebDriver session does not survive a window reload in this Electron setup — no reconnection API exists.
+
+## Known limitations
+
+- **UI tests are inherently slower/flakier than unit tests** — they drive a real Electron app via synthetic Selenium input, which has known timing sensitivities (see below). Treat a UI test failure as a signal to *investigate*, not necessarily a real regression — but also don't reflexively add retries without checking whether the failure is genuinely intermittent (random) vs. consistent (a harness limitation retries can't fix; see PR #68 below).
+- **`quickPrompt.ui.test.ts` used to hang the entire `npm run test:ui` run.** Two tests ("Quick Add Prompt (Selection)", "Refresh Clipboard History adds copied editor text") open a scratch `File: New Text File` buffer and previously never closed it, leaving it dirty. That dirty tab would trigger VS Code's native "Do you want to save?" confirmation the next time `closeAllEditors()` ran (in this suite's own `after()`, transitioning into the next test file) — and once a user or a later step clicks "Save" on a never-saved file, VS Code has to ask *where*, opening an OS-level "Save As" file picker that WebDriver cannot see or interact with at all, hard-hanging the run. Fixed via `revertAllOpenEditors()` (`workbench.action.revertAndCloseActiveEditor`, not `workbench.action.files.revert` — the latter means "reload from disk" and silently no-ops on an untitled buffer that was never saved).
+- **PR #68's E2E hover test was removed, not skipped or retried.** Across every trigger mechanism tried — plain mouse-move dwell, mouse + a "Show or Focus Hover" command, mouse + `this.retries(2)` — the hover tooltip never once rendered within the wait window in this environment. That's a *consistent*, not intermittent, symptom, meaning it's a harness limitation retries can't fix (retries only help with genuinely random flakiness), not a real defect. Forcing it to "pass" via retries would have hidden that fact behind a green checkmark. `isTrusted === false` for both `PromptHoverProvider` and `VersionItem` remains fully covered, without any UI-timing dependency, by `promptHoverProvider.test.ts` and `versionItem.test.ts`.
+- **The `.vscode-test/` and shared `%TEMP%/test-resources` caches are shared across all `vscode-extension-tester`-based projects on this machine** (including `editorGrouper`/VirtualTabs and `Edo-Tensei`) by design — `test:ui` deliberately does **not** pass a project-local `-s`/`--storage` override, so re-running `test:ui` in a sibling project reuses the same downloaded VS Code + ChromeDriver instead of re-downloading ~150MB+ per project.

--- a/docs/TESTING.zh-TW.md
+++ b/docs/TESTING.zh-TW.md
@@ -1,0 +1,86 @@
+# 測試指南(Quick Prompt)
+
+繁體中文 | [English](./TESTING.md)
+
+這是本 repo **自動化**測試套件目前維護中的參考文件,取代 `docs/specs/` 底下較舊的手動測試清單
+(`TESTING_GUIDE.md`、`MCP_CRUD_TEST_CASES.md`、`MCP_E2E_TESTING_GUIDE.md`、
+`PRIVACY_TEST_GUIDE.md`、`20260408_manual_test.md`)。那些文件描述的是 v0.3.0 時代的功能組合
+(例如互動式的 Privacy Dictionary UI),現在的擴充套件裡已經不存在——字典功能在 v2 就被移除,
+改成透過設定檔的自訂規則(見 `src/privacy/maskingEngine.ts`)。那些舊文件僅供歷史參考,
+不要拿來判斷現況的行為或涵蓋範圍。
+
+如果你新增、重新命名或移除測試檔案,請在同一個 PR 裡更新這份文件。
+
+## 如何執行測試
+
+| 套件 | 指令 | 涵蓋範圍 |
+|---|---|---|
+| Root 單元測試 | `npm test` | 針對擴充套件主體程式碼的純 Node/Jest 測試,透過 `src/test/__mocks__/vscode.ts` 模擬 `vscode` 模組 |
+| mcp-server 單元測試 | `cd mcp-server && npm test` | 獨立的 Jest 設定(`mcp-server/jest.config.cjs`),因為 MCP server 套件的模組/tsconfig 設定跟 root 不同,無法共用 root 的 ts-jest 設定 |
+| UI / E2E 測試 | `npm run test:ui` | 用真的 VS Code + Selenium(`vscode-extension-tester`)完整驅動打包好的擴充套件 |
+
+**UI 測試需要一個真的、看得見的 VS Code 視窗,而且要跑好幾分鐘。**
+應該由人在自己的機器上執行,不應該由 AI agent 在沙盒環境裡執行——原因見下方「已知限制」。
+
+mcp-server 這個套件**不屬於** root 的 `npm test` 執行範圍(它的 `src/test/` 檔案雖然目前
+剛好也符合 root Jest 設定的 `testMatch` glob、也剛好能在 root 的 `ts-jest` 設定下通過,
+但它有自己專屬的設定跟指令,並不保證未來一定要繼續維持這種「剛好能跑」的狀態)。
+
+## Root 單元測試(`src/test/unit/`)
+
+| 檔案 | 涵蓋範圍 |
+|---|---|
+| `promptManager.test.ts` | `PromptManager` CRUD:讀寫 prompts.json、損毀/非陣列 JSON 的復原、新增/更新/刪除/釘選/排序/使用次數遞增、樂觀鎖(`OptimisticLockError`)、快取失效 |
+| `versionManager.test.ts` | `VersionManager`:版本歷史 CRUD、損毀/錯誤格式 JSON 的復原、內容未變時去重、里程碑、`MAX_VERSIONS` 上限修剪(保護里程碑)、清除快取、路徑穿越攻擊拒絕 |
+| `versionHistoryService.test.ts` | `VersionHistoryService`:在損毀或錯誤格式的歷史紀錄時載入/重置,fs 錯誤記錄不洩漏原始錯誤/路徑但仍會重新拋出 |
+| `versionCommands.test.ts` | **PR #71** —— `handleShowVersionDiff` 在建立下一個 `TextDocumentContentProvider` 註冊前會先釋放前一個,連續看兩次版本比對不會拋錯 |
+| `versionItem.test.ts` | **PR #68**(安全性)—— `VersionItem` 的 tooltip `MarkdownString` 的 `isTrusted` 為假值,即使里程碑標籤被刻意寫成 `command:` 連結也一樣 |
+| `promptHoverProvider.test.ts` | **PR #68**(安全性)—— 同樣的 `isTrusted` 屬性,針對 `PromptHoverProvider` 由 prompt 標題建構的 hover `MarkdownString` |
+| `promptProviderFsErrorLogging.test.ts` | **PR #67** —— `PromptProvider.savePrompts()` 失敗時只記錄 fs 錯誤代碼,絕不記錄完整工作區路徑 |
+| `promptProviderMultiroot.test.ts` | 多根工作區下 `PromptProvider` 的路由:版本歷史存到正確的工作區、不會覆寫載入失敗的工作區、scope 切換、快速建立目標的解析 |
+| `multiroot.test.ts` | `PromptManager`/MCP 工具層級的多根工作區支援:工作區前綴 ID、路由驗證、主要工作區的退回機制 |
+| `clipboardManager.test.ts` | `ClipboardManager`:重複/過短/純數字內容過濾、損毀歷史 JSON 的復原、**PR #74** fs 錯誤路徑洩漏修復、焦點監聽器的釋放 |
+| `secretStorage.test.ts` | `SecretStorageManager`:資料往返正確性,以及 **PR #69** 對格式錯誤/非物件/非字串的 token map 防呆(回傳 `undefined` 而不是弄壞輸出內容) |
+| `privacyManager.test.ts` | `PrivacyManager`:重複值的還原遮罩,**issue #63** —— 還原時會先處理較長的遮罩值,再處理可能是它字首的較短遮罩值(不受字典新增順序影響),以及 **PR #66** 對格式錯誤的 `privacy-dictionary.json` 防呆。注意:這個類別的字典功能目前只有獨立的 `qp.bundle.js` CLI(也就是 `quickprompt` skill)會用到,VS Code 擴充套件的 UI 完全沒接上——修法是對的,但目前不影響任何 VS Code UI 的使用者 |
+| `maskingEngine.test.ts` | `MaskingEngine` 把它的設定變更監聽器註冊成可釋放物件(資源洩漏防呆) |
+| `mcpConfigPanel.test.ts` | **PR #79**(安全性)—— `escapeHtmlForWebview()` 正確跳脫 `&<>"'`,用來在把工作區名稱插入 MCP config webview 的 HTML 前先做消毒 |
+| `i18n.test.ts` | `I18n`:語系檔遺失或載入失敗時不拋錯、會退回英文,以及 **PR #70** 不記錄原始 error 物件、只記錄語系代碼 |
+| `pathUtils.test.ts` | `PathUtils`:工作區範圍檢查(含路徑穿越、同名前綴的相鄰資料夾攻擊)、路徑解析/相對化、建立目錄、JSON 讀寫、mtime 查詢 |
+| `patternRegistry.test.ts` | `PatternRegistry.mask()`:標籤長度跟符合內容長度不同時的重複比對遮罩、同一個 pattern 出現 3 次以上的情況 |
+| `aiEngine.test.ts` | **PR #77** —— `AIEngine.handleWorkerMessage` 在 worker 發生錯誤時立即拒絕(reject)對應的那一個待處理請求(依 `requestId` 判斷)、不影響其他同時待處理的請求,且訊息沒有 `requestId` 時會退回修復前的全域狀態行為 |
+
+## mcp-server 單元測試(`mcp-server/src/test/`)
+
+| 檔案 | 涵蓋範圍 |
+|---|---|
+| `stateStore.test.ts` | **PR #73** —— `loadState()`/`saveState()`(`~/.quickprompt-mcp-state.json` 這份持久化狀態)對 `null`/陣列/數字/無效 JSON 格式的防呆,遇到這些情況會退回 `{}` 而不是讓整個 MCP server 程序崩潰 |
+| `clipboardTools.test.ts` | **PR #75** —— clipboard MCP 工具不會在 fs 錯誤回應裡洩漏剪貼簿歷史檔案的絕對路徑 |
+
+## UI / E2E 測試(`src/test/ui/`)
+
+每個檔案都會在自己的 `before()` 裡透過 `VSBrowser.instance.openResources(...)` 開啟自己的暫存
+工作區(或自己的 `.code-workspace` fixture)——彼此不共用狀態,不過在一次 `npm run test:ui`
+執行過程中,它們全部都跑在**同一個** VS Code/Chromium 程序裡(mocha 會依序把它們當成
+各自獨立的 `describe` 區塊,依序對各自開啟的工作區執行)。
+
+| 檔案 | 涵蓋範圍 |
+|---|---|
+| `quickPrompt.ui.test.ts` | 核心互動流程:側邊欄渲染、command palette 顯示主要指令、搜尋+複製+使用次數遞增、從樹狀圖開啟並編輯 prompt、新增 Prompt(自動標題/自訂標題)、從選取內容快速新增、Show MCP Config、Refresh Clipboard History |
+| `multiRootQuickPrompt.ui.test.ts` | 透過真實 UI 測試多根工作區行為:預設 scope 下的扁平 prompt 清單、限定 scope 的搜尋、快速新增以當前編輯器所在工作區為目標 |
+| `securityFixes.ui.test.ts` | **PR #79**(安全性)—— 開一個資料夾名稱惡意命名的真實多根工作區,執行「Show MCP Config」,檢查實際的 webview DOM,確認惡意內容只會渲染成無害文字、不會被執行。(**PR #68 的 hover E2E 測試已移除**——見下方「已知限制」;該修復的涵蓋範圍完全由單元測試把關) |
+| `versionDiff.ui.test.ts` | **PR #71** —— 透過真實的樹狀節點點擊,連續看 3 個版本歷史的差異比對,確認每次都正確渲染、不會跳出「無法顯示版本比對」的通知 |
+| `malformedConfigResilience.ui.test.ts` | **PR #66** —— 在開啟工作區**之前**先弄壞 `.vscode/privacy-dictionary.json`,確認擴充套件仍能正常啟動、側邊欄正常渲染、新增 prompt 仍然可用。(**不會**實際測到 `PrivacyManager` 的防呆邏輯本身,因為那個類別根本沒接上擴充套件 UI——只證明擴充套件不會崩潰) |
+| `aiTitleGeneration.ui.test.ts` | **PR #77**,範圍較窄 —— 把 AI provider 指向一個打不通的端點,確認「新增 Prompt(自動標題)」仍然能在幾秒內存下退回用的標題(而不是卡到 90 秒逾時),而且之後擴充套件主體仍保持回應。並沒有重現精確的 `requestId` 拒絕邏輯路徑(見單元測試),因為要真正觸發本地模型 worker 的錯誤需要真的下載模型,而且背景產生標題這個呼叫本來就是即發即忘(fire-and-forget),在 UI 上根本看不出差異 |
+
+### 調查過但沒有寫成測試的項目(原因已寫在對應的測試檔案或 PR 裡)
+
+- **Issue #63**(`PrivacyManager` 子字串標籤還原):無法做 E2E 測試——這個類別完全接不到任何 VS Code 指令或 UI 動作。
+- **PR #69**(`SecretStorageManager` 格式錯誤的 token map):無法做 E2E 測試——token map 只存在 OS 層級的金鑰庫(透過 VS Code 的 `SecretStorage` API),從來不會落地成一個測試可以從外部弄壞的檔案。
+- **PR #78**(`clipboardHistoryView` tree provider 的釋放):唯一能觀察到「釋放失敗」的方式是完整跑一次擴充套件停用/重新啟用的循環(例如「Developer: Reload Window」),但在這個 Electron 環境下,`vscode-extension-tester` 的 WebDriver session 撐不過視窗重新載入——沒有重新連線的 API 可用。
+
+## 已知限制
+
+- **UI 測試天生比單元測試慢、也比較不穩定**——它們透過模擬的 Selenium 輸入去操作一個真的 Electron 應用程式,本來就有已知的時機敏感問題(見下方)。UI 測試失敗應該當成「需要調查」的訊號,不代表一定是真的壞掉——但也不要不分青紅皂白就加重試機制,要先確認失敗是真的偶發(隨機)還是持續性的(重試解決不了的環境限制;見下方 PR #68 的案例)。
+- **`quickPrompt.ui.test.ts` 曾經讓整個 `npm run test:ui` 卡死。** 兩個測試(「Quick Add Prompt (Selection)」、「Refresh Clipboard History adds copied editor text」)會開一個「File: New Text File」暫存分頁,但先前從來沒有關掉,分頁就一直保持骯髒(未儲存)狀態。下次這個套件的 `after()` 執行 `closeAllEditors()`、切換到下一個測試檔案時,這個髒分頁就會觸發 VS Code 原生的「要不要儲存」確認視窗——而一旦有人(或後續某個步驟)對一個從沒存過檔的檔案點了「儲存」,VS Code 就得問「要存去哪」,跳出一個作業系統層級的「另存新檔」檔案選擇視窗,這種視窗 WebDriver 完全看不到、也碰不到,整個執行就會硬生生卡死。修法是用 `revertAllOpenEditors()`(呼叫 `workbench.action.revertAndCloseActiveEditor`,不是 `workbench.action.files.revert`——後者的意思是「從硬碟重新載入」,對一個從沒存過檔的暫存分頁來說會靜默地什麼都不做)。
+- **PR #68 的 E2E hover 測試已經被移除,不是用 skip 或重試蓋過去。** 不管試過哪種觸發方式——單純滑鼠移動 dwell、滑鼠 + 「Show or Focus Hover」指令、滑鼠 + `this.retries(2)` 重試——這個 hover tooltip 在這個環境下**每一次**都沒有在等待時限內渲染出來。這是**持續性**、不是偶發性的症狀,代表這是重試解決不了的環境限制(重試只對真正隨機的不穩定有用),不是真的邏輯缺陷。硬是用重試把它「弄過」,只會把這個事實藏在一個綠色勾勾後面。`PromptHoverProvider` 跟 `VersionItem` 的 `isTrusted === false` 這個屬性,完全由 `promptHoverProvider.test.ts` 跟 `versionItem.test.ts` 涵蓋,而且不依賴任何 UI 時機。
+- **`.vscode-test/` 跟共用的 `%TEMP%/test-resources` 快取,設計上會跟這台機器上所有用 `vscode-extension-tester` 的專案共用**(包含 `editorGrouper`/VirtualTabs 跟 `Edo-Tensei`)——`test:ui` 刻意**沒有**傳入專案自己的 `-s`/`--storage` 覆寫路徑,所以在其他姊妹專案裡重跑 `test:ui` 時,會直接沿用同一份已下載的 VS Code + ChromeDriver,而不是每個專案各自重新下載一份(~150MB 以上)。

--- a/docs/TESTING.zh-TW.md
+++ b/docs/TESTING.zh-TW.md
@@ -2,12 +2,10 @@
 
 繁體中文 | [English](./TESTING.md)
 
-這是本 repo **自動化**測試套件目前維護中的參考文件,取代 `docs/specs/` 底下較舊的手動測試清單
-(`TESTING_GUIDE.md`、`MCP_CRUD_TEST_CASES.md`、`MCP_E2E_TESTING_GUIDE.md`、
-`PRIVACY_TEST_GUIDE.md`、`20260408_manual_test.md`)。那些文件描述的是 v0.3.0 時代的功能組合
-(例如互動式的 Privacy Dictionary UI),現在的擴充套件裡已經不存在——字典功能在 v2 就被移除,
-改成透過設定檔的自訂規則(見 `src/privacy/maskingEngine.ts`)。那些舊文件僅供歷史參考,
-不要拿來判斷現況的行為或涵蓋範圍。
+這是本 repo **自動化**測試套件目前維護中的參考文件。補充背景:`PrivacyManager` 的字典功能
+(見下方單元測試表格)在 v2 改版時已經被透過設定檔的自訂規則取代
+(`src/privacy/maskingEngine.ts`)——如果你在本機看到其他描述互動式 Privacy Dictionary UI
+的舊筆記,那個功能已經不存在了,不要拿來判斷現況的行為或涵蓋範圍。
 
 如果你新增、重新命名或移除測試檔案,請在同一個 PR 裡更新這份文件。
 

--- a/mcp-server/jest.config.cjs
+++ b/mcp-server/jest.config.cjs
@@ -1,0 +1,14 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  rootDir: __dirname,
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/test/**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -9,7 +9,8 @@
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "dev": "tsc && node dist/index.js",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "jest --runInBand"
   },
   "keywords": [
     "mcp",
@@ -26,7 +27,10 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/node": "^20.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
     "typescript": "^5.3.0"
   },
   "engines": {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -10,39 +10,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { QuickPromptMCPServer } from './server.js';
-
-/** State file stored at ~/.quickprompt-mcp-state.json */
-const STATE_FILE = path.join(os.homedir(), '.quickprompt-mcp-state.json');
-
-interface McpState {
-  lastWorkspaceRoot?: string;
-}
-
-function loadState(): McpState {
-  try {
-    if (fs.existsSync(STATE_FILE)) {
-      const raw = fs.readFileSync(STATE_FILE, 'utf-8');
-      const parsed: unknown = JSON.parse(raw);
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        return parsed as McpState;
-      }
-    }
-  } catch {
-    // Ignore read/parse errors; treat as empty state
-  }
-  return {};
-}
-
-function saveState(state: McpState): void {
-  try {
-    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), 'utf-8');
-  } catch {
-    // Ignore write errors (non-critical for core functionality)
-  }
-}
+import { loadState, saveState } from './stateStore.js';
 
 /**
  * Parse optional command-line arguments.

--- a/mcp-server/src/stateStore.ts
+++ b/mcp-server/src/stateStore.ts
@@ -1,0 +1,51 @@
+/**
+ * QuickPrompt MCP Server persisted state helpers.
+ *
+ * Isolated from index.ts (no dependency on the MCP SDK / server graph) so that
+ * loadState()/saveState() can be unit-tested in isolation without pulling in
+ * the whole stdio transport + tool registration machinery.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/** Default state file location: ~/.quickprompt-mcp-state.json */
+export const STATE_FILE = path.join(os.homedir(), '.quickprompt-mcp-state.json');
+
+export interface McpState {
+  lastWorkspaceRoot?: string;
+}
+
+/**
+ * Load persisted state from disk.
+ *
+ * Guards against malformed JSON shapes (null, arrays, primitives, etc.) that
+ * would otherwise flow an invalid value into callers typed as McpState -
+ * falls back to an empty state object `{}` for anything that isn't a plain
+ * object, as well as for any read/parse error.
+ *
+ * @param filePath Optional override of the state file path (used by tests).
+ */
+export function loadState(filePath: string = STATE_FILE): McpState {
+  try {
+    if (fs.existsSync(filePath)) {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as McpState;
+      }
+    }
+  } catch {
+    // Ignore read/parse errors; treat as empty state
+  }
+  return {};
+}
+
+export function saveState(state: McpState, filePath: string = STATE_FILE): void {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(state, null, 2), 'utf-8');
+  } catch {
+    // Ignore write errors (non-critical for core functionality)
+  }
+}

--- a/mcp-server/src/test/clipboardTools.test.ts
+++ b/mcp-server/src/test/clipboardTools.test.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+
+import { ClipboardTools } from '../tools/clipboardTools.js';
+
+// TypeScript's CJS interop helper freezes the `fs` namespace object, so
+// `jest.spyOn(fs, ...)` cannot redefine its properties. Mocking the whole
+// module (keeping the real implementation for anything we don't override)
+// sidesteps that and lets us control existsSync/readFileSync per test.
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
+const mockedExistsSync = fs.existsSync as jest.Mock;
+const mockedReadFileSync = fs.readFileSync as jest.Mock;
+
+describe('ClipboardTools error message leakage', () => {
+  const fakePath = 'C:\\Users\\fakeuser\\.quickprompt\\clipboard-history.json';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not leak the clipboard history file path when the fs read fails', async () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockImplementation(() => {
+      const err = new Error(
+        `EACCES: permission denied, open '${fakePath}'`
+      ) as NodeJS.ErrnoException;
+      err.code = 'EACCES';
+      throw err;
+    });
+
+    const tools = new ClipboardTools();
+    const result = await tools.getClipboardItem({ index: 0 });
+
+    expect(result.success).toBe(false);
+    const message = result.success ? '' : result.message;
+
+    // Must not leak the absolute path or the username embedded in it.
+    expect(message).not.toContain(fakePath);
+    expect(message).not.toContain('fakeuser');
+
+    // Should still surface the error code so callers can diagnose the failure.
+    expect(message).toContain('EACCES');
+  });
+});

--- a/mcp-server/src/test/stateStore.test.ts
+++ b/mcp-server/src/test/stateStore.test.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { loadState, saveState, McpState } from '../stateStore.js';
+
+describe('stateStore', () => {
+  let tmpDir: string;
+  let statePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'quickprompt-mcp-state-test-'));
+    statePath = path.join(tmpDir, 'state.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('loadState', () => {
+    it('returns {} when the file does not exist', () => {
+      expect(loadState(statePath)).toEqual({});
+    });
+
+    it('returns {} when the file contains a JSON null', () => {
+      fs.writeFileSync(statePath, 'null', 'utf-8');
+      expect(loadState(statePath)).toEqual({});
+    });
+
+    it('returns {} when the file contains a bare JSON array', () => {
+      fs.writeFileSync(statePath, '["a", "b"]', 'utf-8');
+      expect(loadState(statePath)).toEqual({});
+    });
+
+    it('returns {} when the file contains a bare JSON number', () => {
+      fs.writeFileSync(statePath, '42', 'utf-8');
+      expect(loadState(statePath)).toEqual({});
+    });
+
+    it('returns {} when the file contains invalid JSON', () => {
+      fs.writeFileSync(statePath, '{ not valid json', 'utf-8');
+      expect(loadState(statePath)).toEqual({});
+    });
+
+    it('round-trips a valid state object', () => {
+      const state: McpState = { lastWorkspaceRoot: '/some/workspace' };
+      saveState(state, statePath);
+      expect(loadState(statePath)).toEqual(state);
+    });
+  });
+
+  describe('saveState', () => {
+    it('writes JSON that can be read back', () => {
+      saveState({ lastWorkspaceRoot: 'C:/repo' }, statePath);
+      const raw = fs.readFileSync(statePath, 'utf-8');
+      expect(JSON.parse(raw)).toEqual({ lastWorkspaceRoot: 'C:/repo' });
+    });
+  });
+});

--- a/mcp-server/tsconfig.test.json
+++ b/mcp-server/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -620,7 +620,7 @@
         "test:coverage": "jest --runInBand --coverage",
         "test:watch": "jest --watch",
         "test:ui:setup": "extest setup-tests",
-        "test:ui": "node -e \"require('fs').rmSync('out/test/ui',{recursive:true,force:true})\" && tsc -p tsconfig.test.ui.json && extest setup-and-run \"out/test/ui/**/*.test.js\" -e \".vscode-test/extensions\" -s \".vscode-test/test-resources-vscode-1.96\" -c 1.96.0"
+        "test:ui": "node -e \"require('fs').rmSync('out/test/ui',{recursive:true,force:true})\" && tsc -p tsconfig.test.ui.json && extest setup-and-run \"out/test/ui/**/*.test.js\" -e \".vscode-test/extensions\" -c 1.96.0"
     },
     "devDependencies": {
         "@types/chai": "^5.2.3",

--- a/src/core/PrivacyManager.ts
+++ b/src/core/PrivacyManager.ts
@@ -159,7 +159,13 @@ export class PrivacyManager {
      */
     unmaskText(maskedText: string): string {
         let result = maskedText;
-        for (const [maskedValue, token] of this.tokenStore) {
+        // Longer masked values first: a shorter custom-dictionary label that
+        // is a literal substring of a longer one (e.g. "[SECRET]" is a
+        // substring of "[SECRET]-BACKUP") must not be substituted before the
+        // longer, more specific label gets its turn — restoring it first
+        // would corrupt the still-unprocessed longer occurrence.
+        const entries = [...this.tokenStore].sort(([a], [b]) => b.length - a.length);
+        for (const [maskedValue, token] of entries) {
             if (token.reversible && result.includes(maskedValue)) {
                 // split/join replaces every occurrence — String.replace(string) only replaces the first
                 result = result.split(maskedValue).join(token.originalValue);

--- a/src/promptProvider.ts
+++ b/src/promptProvider.ts
@@ -32,8 +32,17 @@ export type PromptTreeItem = PromptItem | VersionItem;
  * fs.statSync/readFile 等錯誤訊息中內嵌的完整工作區路徑寫入日誌。
  */
 function formatFsErrorForLog(error: unknown): string {
-    const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
-    return code ?? (error instanceof Error ? error.name : 'unknown error');
+    // Duck-type rather than gate on `instanceof Error`: fs errors crossing a
+    // VM/realm boundary (e.g. Jest's per-file context) can carry a proper
+    // `.code`/`.message` shape without passing `instanceof Error` here.
+    if (typeof error === 'object' && error !== null && 'code' in error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code) return code;
+    }
+    if (typeof error === 'object' && error !== null && 'name' in error && typeof (error as { name: unknown }).name === 'string') {
+        return (error as { name: string }).name;
+    }
+    return 'unknown error';
 }
 
 export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -6,6 +6,16 @@ interface MockWorkspaceFolder {
     name: string
 }
 
+interface TextDocumentContentProviderLike {
+    provideTextDocumentContent(uri: Uri): string | Thenable<string | undefined | null> | undefined | null
+}
+
+// Tracks the currently-registered content provider per scheme, mirroring real
+// VS Code's rule that only one TextDocumentContentProvider may be registered
+// per URI scheme at a time. Registering a second provider for the same scheme
+// without disposing the first throws, so tests can exercise that failure mode.
+const registeredContentProviderSchemes = new Set<string>()
+
 export const workspace: {
     getConfiguration: (_section?: string) => { get: <T>(_key: string, defaultValue: T) => T }
     workspaceFolders: undefined | MockWorkspaceFolder[]
@@ -14,6 +24,7 @@ export const workspace: {
     onDidChangeConfiguration: (_listener: unknown) => { dispose: () => undefined }
     onDidChangeWorkspaceFolders: (_listener: unknown) => { dispose: () => undefined }
     createFileSystemWatcher: jest.Mock
+    registerTextDocumentContentProvider: (scheme: string, provider: TextDocumentContentProviderLike) => { dispose: () => void }
     fs: {
         readFile: (uri: Uri) => Promise<Uint8Array>
         writeFile: (uri: Uri, content: Uint8Array) => Promise<void>
@@ -37,6 +48,22 @@ export const workspace: {
         onDidDelete: jest.fn(),
         dispose: jest.fn(),
     })),
+    registerTextDocumentContentProvider: (scheme: string, _provider: TextDocumentContentProviderLike) => {
+        if (registeredContentProviderSchemes.has(scheme)) {
+            throw new Error(`A content provider for scheme '${scheme}' is already registered`)
+        }
+        registeredContentProviderSchemes.add(scheme)
+        let disposed = false
+        return {
+            dispose: () => {
+                if (disposed) {
+                    return
+                }
+                disposed = true
+                registeredContentProviderSchemes.delete(scheme)
+            },
+        }
+    },
     fs: {
         readFile: async (uri: Uri): Promise<Uint8Array> => {
             try {
@@ -189,6 +216,40 @@ export const window = {
         visible: false,
         selection: [],
     })),
+    registerTreeDataProvider: jest.fn(() => ({ dispose: jest.fn() })),
+}
+
+export class MarkdownString {
+    value: string
+    isTrusted?: boolean | { enabledCommands: readonly string[] }
+    supportHtml?: boolean
+    supportThemeIcons?: boolean
+
+    constructor(value: string = '') {
+        this.value = value
+    }
+
+    appendText(value: string): MarkdownString {
+        this.value += value
+        return this
+    }
+
+    appendMarkdown(value: string): MarkdownString {
+        this.value += value
+        return this
+    }
+
+    appendCodeblock(value: string, language?: string): MarkdownString {
+        this.value += `\n\`\`\`${language ?? ''}\n${value}\n\`\`\`\n`
+        return this
+    }
+}
+
+export class Hover {
+    constructor(
+        public readonly contents: MarkdownString | MarkdownString[],
+        public readonly range?: unknown,
+    ) {}
 }
 
 export const FileSystemError = {

--- a/src/test/ui/aiTitleGeneration.ui.test.ts
+++ b/src/test/ui/aiTitleGeneration.ui.test.ts
@@ -1,0 +1,321 @@
+import {
+    ActivityBar,
+    EditorView,
+    TextEditor,
+    ViewControl,
+    VSBrowser,
+    Workbench,
+} from 'vscode-extension-tester';
+import { By, Key } from 'selenium-webdriver';
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * E2E coverage attempt for PR #77: "fail fast on worker summarize error
+ * instead of waiting for the 90s timeout".
+ *
+ * ── Feasibility investigation (read this before extending the file) ──
+ *
+ * PR #77's actual fix lives in `AIEngine.handleWorkerMessage()`
+ * (src/ai/aiEngine.ts): when the `local-qwen` worker_thread reports an
+ * `{ type: 'error', requestId, error }` message, the engine now rejects the
+ * one matching pending request immediately instead of leaving it to be
+ * rescued by `summarizeViaWorker()`'s own 90s `setTimeout` fallback. That
+ * fix is already covered thoroughly at the unit level in
+ * src/test/unit/aiEngine.test.ts by driving `handleWorkerMessage()` with
+ * synthetic messages.
+ *
+ * Reproducing that exact path through a real E2E run turns out to be
+ * impractical, for two independent reasons:
+ *
+ * 1. Reaching it at all requires the `local-qwen` provider's worker_thread
+ *    to reach `status: 'ready'` first (see `initializeQwen()` /
+ *    `aiWorker.ts`'s `initialize()`), which means actually downloading a
+ *    real transformers.js model (SmolLM2/Qwen3, tens to hundreds of MB)
+ *    from the Hugging Face hub. That's slow, network-dependent, and
+ *    non-deterministic — exactly what a fast, offline-friendly E2E test
+ *    should avoid. `aiWorker.ts`'s `summarize()` only throws synchronously
+ *    for `!generator` (i.e. "not ready yet"), which is a *different* code
+ *    path (never reaches `pendingRequests`) than a genuine post-ready
+ *    generation failure — there is no documented way to make a *ready*
+ *    local model throw on demand via ordinary user input.
+ *
+ * 2. Even if a genuine worker error were forced, it would not be
+ *    observable from the UI/E2E layer. Title generation is deliberately
+ *    fire-and-forget everywhere it's used (see the un-awaited
+ *    `titleGenService.generateProgressively(...)` calls in
+ *    `src/extension.ts`'s file-system write callback and in
+ *    `src/commands.ts`), and `TitleGenerationService.generateProgressively`
+ *    itself never awaits `generateAITitleInBackground`. So "Add Prompt
+ *    (Auto Title)" always returns/saves using the synchronous fallback
+ *    title, and the AI Engine's internal bookkeeping (pending-request map,
+ *    global `status`) that PR #77 fixes is invisible to anything a
+ *    WebDriver test can observe — there is no DOM state, notification, or
+ *    persisted-file difference between the fixed and buggy engine from the
+ *    outside.
+ *
+ * Given that, this file does NOT attempt to reproduce PR #77's exact code
+ * path. Instead it exercises the best available proxy suggested by the
+ * task: it forces AI generation down a real, fast-failing path (an
+ * `openai-compatible` endpoint pointed at a port nothing listens on) and
+ * asserts that "Add Prompt (Auto Title)" still completes and persists a
+ * usable title well within seconds — not anywhere near the 90s timeout —
+ * and that the extension host stays responsive afterwards. This is a
+ * narrower "the UI never hangs on AI, regardless of how AI fails" smoke
+ * test rather than a precise regression test for the specific fix.
+ *
+ * `openai-compatible` is deliberately used instead of `local-qwen` here:
+ * `AIEngine.initializeOpenAI()` marks the engine `ready` synchronously
+ * without validating connectivity ("實際連線在首次呼叫 summarize() 時才驗證"),
+ * so no model download or warm-up is needed to reach the code path that
+ * actually calls out and fails.
+ *
+ * If a *precise* E2E reproduction of PR #77 is wanted in the future, the
+ * minimum missing piece is a test-only seam to inject a fake AI backend
+ * that the extension host can reach without real hardware/network — e.g.
+ * an env-var-gated "mock worker" module swapped in for `aiWorker.js`, or a
+ * lightweight local HTTP server the `openai-compatible` provider can point
+ * at that responds instantly with a canned error — combined with a way for
+ * the test to observe when the background title-update callback has run
+ * (there is currently no event/hook for that; it would need one, e.g. a
+ * command like `quickPrompt._test.waitForTitleGeneration`).
+ */
+
+interface PromptRecord {
+    id: string;
+    title: string;
+    content: string;
+    use_count: number;
+    last_used: string;
+    created_at: string;
+    pinned: boolean;
+    titleSource?: 'user' | 'ai';
+    order?: number;
+    meta?: {
+        totalVersions: number;
+        latestVersionId?: string;
+    };
+    ignorePrivacyWarning?: boolean;
+}
+
+let workspaceRoot = '';
+let vscodeDir = '';
+let promptsPath = '';
+
+// A loopback port nothing listens on. Connections to it fail almost
+// instantly with ECONNREFUSED (no proxy involved, since it's localhost),
+// which is what makes the "fails fast, doesn't hang" assertion meaningful
+// without relying on any timeout actually elapsing.
+const UNREACHABLE_ENDPOINT = 'http://127.0.0.1:1/v1';
+
+function createTestWorkspace(): void {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'quick-prompt-ai-ui-'));
+    vscodeDir = path.join(workspaceRoot, '.vscode');
+    promptsPath = path.join(vscodeDir, 'prompts.json');
+}
+
+function seedWorkspaceData(): void {
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(promptsPath, JSON.stringify([], null, 2), 'utf8');
+
+    const settings = {
+        'quickPrompt.ai.enabled': true,
+        'quickPrompt.ai.provider': 'openai-compatible',
+        'quickPrompt.ai.features.titleGeneration': true,
+        'quickPrompt.ai.openaiCompatible.endpoint': UNREACHABLE_ENDPOINT,
+        // 3000 is the schema minimum; kept short so a stuck connection
+        // (rather than an immediate refusal) still can't stall the test.
+        'quickPrompt.ai.openaiCompatible.timeout': 3000,
+    };
+    fs.writeFileSync(
+        path.join(vscodeDir, 'settings.json'),
+        JSON.stringify(settings, null, 2),
+        'utf8'
+    );
+}
+
+function cleanupTestWorkspace(): void {
+    if (!workspaceRoot) {
+        return;
+    }
+    try {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    } catch {
+        // VS Code may still hold a handle during shutdown on Windows.
+    }
+}
+
+let viewControl: ViewControl;
+
+describe('Quick Prompt - AI title generation failure UI / E2E', function () {
+    this.timeout(120_000);
+
+    before(async function () {
+        createTestWorkspace();
+        seedWorkspaceData();
+
+        await VSBrowser.instance.waitForWorkbench();
+        await VSBrowser.instance.openResources(workspaceRoot);
+        await dismissOnboardingOverlay();
+
+        const driver = VSBrowser.instance.driver;
+        await driver.wait(async () => {
+            try {
+                const wb = await driver.findElement(By.css('.monaco-workbench'));
+                return await wb.isDisplayed();
+            } catch { return false; }
+        }, 30_000, 'Monaco workbench did not appear');
+        await driver.sleep(2000);
+
+        const activityBar = new ActivityBar();
+        let foundControl: ViewControl | undefined;
+        for (let i = 0; i < 5; i++) {
+            try {
+                foundControl = await activityBar.getViewControl('Quick Prompt');
+                if (foundControl) { break; }
+            } catch { /* retry */ }
+            await driver.sleep(1500);
+        }
+        expect(foundControl, 'Quick Prompt icon not found in Activity Bar').to.not.be.undefined;
+        viewControl = foundControl!;
+        await retryCommand('Refresh Prompts');
+    });
+
+    after(async function () {
+        await closeQuickInput();
+        try {
+            await new EditorView().closeAllEditors();
+        } catch {
+            // A failed test can leave a modal dialog open. Browser shutdown will clean up the UI.
+        }
+        cleanupTestWorkspace();
+    });
+
+    it('Add Prompt (Auto Title) persists a usable title within seconds, not the 90s AI timeout, when the configured AI endpoint is unreachable', async function () {
+        const marker = uniqueMarker('ai-fail-fast-content');
+        const startedAt = Date.now();
+
+        await runCommandViaKeyboard('Add Prompt (Auto Title)');
+        const activeEditor = new TextEditor();
+        await activeEditor.setText(marker);
+        await activeEditor.save();
+
+        // Bound is generous for a slow CI machine but nowhere near the 90s
+        // worker timeout this scenario exists to guard against.
+        const persistedPrompt = await waitForPromptRecord(undefined, prompt =>
+            prompt.content.includes(marker) &&
+            prompt.titleSource === 'ai' &&
+            prompt.title.trim().length > 0,
+            20_000
+        );
+
+        const elapsedMs = Date.now() - startedAt;
+        expect(elapsedMs, `Add Prompt (Auto Title) took ${elapsedMs}ms to persist`).to.be.lessThan(20_000);
+        expect(persistedPrompt.title.toLowerCase()).to.not.equal('untitled prompt');
+    });
+
+    it('extension host stays responsive after the background AI request fails', async function () {
+        // Give the fire-and-forget background summarize() attempt time to
+        // actually hit the unreachable endpoint and fail, so this assertion
+        // isn't just "the previous test's editor.save() was fast".
+        await VSBrowser.instance.driver.sleep(4000);
+
+        await retryCommand('Refresh Prompts');
+
+        const driver = VSBrowser.instance.driver;
+        const sawToast = await driver.wait(async () => {
+            try {
+                const toasts = await driver.findElements(By.css('.notification-toast'));
+                for (const toast of toasts) {
+                    const text = (await toast.getText()).toLowerCase();
+                    if (text.includes('refresh')) {
+                        return true;
+                    }
+                }
+            } catch {
+                // DOM may be re-rendering
+            }
+            return false;
+        }, 10_000, 'Refresh Prompts toast notification did not appear').catch(() => false);
+
+        // The toast text is localized and best-effort to match; what this
+        // test really guards is that the command round-trip below completed
+        // at all within its own wait, proving the extension host was not
+        // wedged by the earlier failed AI call.
+        expect(typeof sawToast).to.equal('boolean');
+    });
+});
+
+async function dismissOnboardingOverlay(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    try {
+        const overlay = await driver.findElement(By.css('.onboarding-a-overlay.visible'));
+        if (await overlay.isDisplayed()) {
+            await driver.executeScript('arguments[0].remove()', overlay);
+        }
+    } catch {
+        // Overlay is not present in most test runs.
+    }
+}
+
+async function runCommandViaKeyboard(commandLabel: string): Promise<void> {
+    await new Workbench().executeCommand(commandLabel);
+}
+
+async function retryCommand(commandLabel: string, retries = 3): Promise<void> {
+    for (let i = 0; i < retries; i++) {
+        try {
+            await closeQuickInput();
+            await runCommandViaKeyboard(commandLabel);
+            return;
+        } catch {
+            await VSBrowser.instance.driver.sleep(1500);
+        }
+    }
+    await runCommandViaKeyboard(commandLabel);
+}
+
+async function closeQuickInput(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    await resetKeyboardState();
+    await driver.actions().sendKeys(Key.ESCAPE).perform();
+    await driver.sleep(200);
+}
+
+async function resetKeyboardState(): Promise<void> {
+    await VSBrowser.instance.driver.actions().sendKeys(Key.NULL).perform();
+}
+
+function readPromptsFile(): PromptRecord[] {
+    try {
+        return JSON.parse(fs.readFileSync(promptsPath, 'utf8')) as PromptRecord[];
+    } catch {
+        // File may be mid-write; return empty so the poller retries
+        return [];
+    }
+}
+
+async function waitForPromptRecord(
+    id: string | undefined,
+    predicate: (prompt: PromptRecord) => boolean,
+    timeoutMs = 10_000
+): Promise<PromptRecord> {
+    const driver = VSBrowser.instance.driver;
+
+    const promptRecord = await driver.wait(() => {
+        const prompts = readPromptsFile();
+        const found = prompts.find(prompt =>
+            (id === undefined || prompt.id === id) &&
+            predicate(prompt)
+        );
+        return found || false;
+    }, timeoutMs, 'Expected prompt record was not persisted');
+
+    return promptRecord as PromptRecord;
+}
+
+function uniqueMarker(prefix: string): string {
+    return `ui-test-${prefix}-${Date.now()}`;
+}

--- a/src/test/ui/malformedConfigResilience.ui.test.ts
+++ b/src/test/ui/malformedConfigResilience.ui.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Malformed on-disk config resilience — UI / E2E
+ * ================================================
+ *
+ * Covers the "extension doesn't fall over when a config file has an
+ * unexpected shape" bugfixes from PR #66 and PR #69. Both already have
+ * solid unit coverage (src/test/unit/privacyManager.test.ts,
+ * src/test/unit/secretStorage.test.ts) that exercises the guard clauses
+ * directly. This file's job is different: does the REAL, running
+ * extension keep working when the artifact is corrupted on disk before
+ * VS Code even opens the workspace.
+ *
+ * IMPORTANT HONESTY NOTE — please read before extending this file:
+ *
+ * - PR #66 (PrivacyManager dictionary shape guard, src/core/PrivacyManager.ts)
+ *   guards `.vscode/privacy-dictionary.json`. Investigation of the shipped
+ *   extension runtime (src/extension.ts, src/promptProvider.ts,
+ *   src/commands.ts) shows `PrivacyManager` is NOT instantiated anywhere in
+ *   the VS Code extension host — it is exported from src/core/index.ts for
+ *   the standalone `qp.bundle.js` CLI (built via `npm run build:qp`, shipped
+ *   as the `quickprompt` Claude Code skill), a separate Node process outside
+ *   VS Code. The extension's own privacy/masking feature
+ *   (src/privacy/maskingEngine.ts) explicitly says "Dictionary feature
+ *   removed in v2 — custom rules via settings instead" and always calls
+ *   `enableCustom: false`. So a corrupted `.vscode/privacy-dictionary.json`
+ *   is never read by the running extension today — there is no reachable
+ *   crash to reproduce at the UI level for PR #66 as things currently stand.
+ *   The test below is kept anyway as a narrow, honestly-scoped smoke test:
+ *   it proves a stray/corrupted dictionary file sitting in `.vscode/` causes
+ *   no adverse effect on activation or normal use (defends against any
+ *   future code path that starts reading this file, and guards against
+ *   unrelated regressions like a blind directory scan). It does NOT
+ *   exercise `PrivacyManager.loadDictionary()`'s guard clause itself — that
+ *   verification only exists at the unit-test level.
+ *
+ * - PR #69 (SecretStorageManager token map shape guard,
+ *   src/privacy/masking/secretStorage.ts) IS wired into the real extension
+ *   (src/promptProvider.ts constructs it from `context.secrets` and uses it
+ *   for the Mask/Unmask Prompt commands). However its own file header says
+ *   plainly: "Stores tokenMap per prompt using VS Code SecretStorage API
+ *   (OS-level encrypted). The tokenMap never touches disk — it lives only
+ *   in the OS keychain." There is no workspace file, extension global-state
+ *   JSON, or other on-disk artifact to corrupt from outside the process in
+ *   order to reproduce the malformed shape; doing so would require mocking
+ *   `vscode.SecretStorage` at the unit level, which the existing unit test
+ *   already does. Writing an E2E test that pretends to corrupt "the" secret
+ *   storage file would be misleading (there isn't one), so PR #69 is
+ *   deliberately NOT covered here.
+ */
+
+import {
+    ActivityBar,
+    SideBarView,
+    ViewControl,
+    VSBrowser,
+    Workbench,
+} from 'vscode-extension-tester';
+import { By, Key, WebElement } from 'selenium-webdriver';
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+interface PromptRecord {
+    id: string;
+    title: string;
+    content: string;
+    use_count: number;
+    last_used: string;
+    created_at: string;
+    pinned: boolean;
+    titleSource?: 'user' | 'ai';
+    order?: number;
+    meta?: {
+        totalVersions: number;
+        latestVersionId?: string;
+    };
+    ignorePrivacyWarning?: boolean;
+}
+
+let workspaceRoot = '';
+let vscodeDir = '';
+let promptsPath = '';
+let dictionaryPath = '';
+let viewControl: ViewControl;
+
+const seededPrompt: PromptRecord = {
+    id: '9101',
+    title: 'Malformed Config Seed Prompt',
+    content: 'Seed content used to confirm the sidebar renders normally.',
+    use_count: 0,
+    last_used: '2026-08-18',
+    created_at: '2026-08-18T00:00:00.000Z',
+    pinned: false,
+    titleSource: 'user',
+    order: 0,
+    meta: { totalVersions: 0, latestVersionId: '' },
+    ignorePrivacyWarning: false,
+};
+
+describe('Quick Prompt - Malformed config resilience UI / E2E', function () {
+    this.timeout(120_000);
+
+    before(async function () {
+        createIsolatedWorkspace();
+        // Corrupt the file BEFORE VS Code ever opens the workspace, so any
+        // read-on-activation path (present or future) sees the bad shape
+        // from the very first activation, not after a later re-read.
+        writeMalformedPrivacyDictionary();
+        seedPrompts();
+
+        await VSBrowser.instance.waitForWorkbench();
+        await VSBrowser.instance.openResources(workspaceRoot);
+        await dismissOnboardingOverlay();
+
+        const driver = VSBrowser.instance.driver;
+        await driver.wait(async () => {
+            try {
+                const wb = await driver.findElement(By.css('.monaco-workbench'));
+                return await wb.isDisplayed();
+            } catch { return false; }
+        }, 30_000, 'Monaco workbench did not appear');
+        await driver.sleep(2000);
+
+        const activityBar = new ActivityBar();
+        let foundControl: ViewControl | undefined;
+        for (let i = 0; i < 5; i++) {
+            try {
+                foundControl = await activityBar.getViewControl('Quick Prompt');
+                if (foundControl) { break; }
+            } catch { /* retry while extension host is activating */ }
+            await driver.sleep(1500);
+        }
+        expect(foundControl, 'Quick Prompt icon not found in Activity Bar — extension likely failed to activate with a malformed privacy-dictionary.json present').to.not.be.undefined;
+        viewControl = foundControl!;
+        await retryCommand('Refresh Prompts');
+    });
+
+    after(async function () {
+        await closeQuickInput();
+        cleanupIsolatedWorkspace();
+    });
+
+    it('activates without an error notification when .vscode/privacy-dictionary.json has a malformed shape', async function () {
+        const driver = VSBrowser.instance.driver;
+
+        const errorToasts = await driver.findElements(By.css('.notification-toast.severity-error'));
+        const errorTexts: string[] = [];
+        for (const toast of errorToasts) {
+            try {
+                errorTexts.push((await toast.getText()).toLowerCase());
+            } catch { /* toast may have dismissed itself */ }
+        }
+        const relevantErrors = errorTexts.filter(t => t.includes('quick prompt') || t.includes('privacy') || t.includes('dictionary'));
+        expect(relevantErrors, `Unexpected error notification(s) referencing privacy/dictionary: ${JSON.stringify(relevantErrors)}`).to.have.lengthOf(0);
+    });
+
+    it('renders the Quick Prompt sidebar normally despite the malformed dictionary file', async function () {
+        expect(await viewControl.getTitle()).to.equal('Quick Prompt');
+
+        const sidebar = (await viewControl.openView()) as SideBarView;
+        const title = await sidebar.getTitlePart().getTitle();
+        expect(title.toLowerCase()).to.include('quick prompt');
+
+        const sections = await sidebar.getContent().getSections();
+        const titles = await Promise.all(sections.map(s => s.getTitle()));
+        expect(titles.some(t => /prompt/i.test(t))).to.be.true;
+        expect(titles.some(t => /clipboard/i.test(t))).to.be.true;
+
+        const seededRow = await waitForWorkbenchText('Malformed Config Seed Prompt');
+        expect(seededRow).to.include('Malformed Config Seed Prompt');
+    });
+
+    it('still supports adding a prompt normally with the malformed dictionary file present', async function () {
+        const title = uniqueMarker('malformed-dict-add-title');
+        const content = uniqueMarker('malformed-dict-add-content');
+
+        await runCommandViaKeyboard('Add Prompt (Custom Title)');
+        await waitForQuickInputText('Set title for this prompt');
+        await replaceQuickInputText(title);
+        await acceptQuickInput();
+        await waitForQuickInputText('Enter Prompt content');
+        await replaceQuickInputText(content);
+        await acceptQuickInput();
+
+        await waitForPromptRecord(prompt =>
+            prompt.title === title &&
+            prompt.content === content &&
+            prompt.titleSource === 'user'
+        );
+
+        // The dictionary file itself should still be exactly what we wrote —
+        // nothing in this flow should have touched or "fixed" it up.
+        const stillMalformed = fs.readFileSync(dictionaryPath, 'utf8');
+        expect(JSON.parse(stillMalformed)).to.deep.equal({ entries: null });
+    });
+});
+
+function createIsolatedWorkspace(): void {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'quick-prompt-malformed-config-ui-'));
+    vscodeDir = path.join(workspaceRoot, '.vscode');
+    promptsPath = path.join(vscodeDir, 'prompts.json');
+    dictionaryPath = path.join(vscodeDir, 'privacy-dictionary.json');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+}
+
+function writeMalformedPrivacyDictionary(): void {
+    // Shape from PR #66: parses as valid JSON but `entries` is not an array.
+    fs.writeFileSync(dictionaryPath, JSON.stringify({ entries: null }), 'utf8');
+}
+
+function seedPrompts(): void {
+    fs.writeFileSync(promptsPath, JSON.stringify([seededPrompt], null, 2), 'utf8');
+}
+
+function cleanupIsolatedWorkspace(): void {
+    if (!workspaceRoot) {
+        return;
+    }
+    try {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    } catch {
+        // VS Code may still hold a handle during shutdown on Windows.
+    }
+}
+
+async function dismissOnboardingOverlay(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    try {
+        const overlay = await driver.findElement(By.css('.onboarding-a-overlay.visible'));
+        if (await overlay.isDisplayed()) {
+            await driver.executeScript('arguments[0].remove()', overlay);
+        }
+    } catch {
+        // Overlay is not present in most test runs.
+    }
+}
+
+async function runCommandViaKeyboard(commandLabel: string): Promise<void> {
+    await new Workbench().executeCommand(commandLabel);
+}
+
+async function retryCommand(commandLabel: string, retries = 3): Promise<void> {
+    for (let i = 0; i < retries; i++) {
+        try {
+            await closeQuickInput();
+            await runCommandViaKeyboard(commandLabel);
+            return;
+        } catch {
+            await VSBrowser.instance.driver.sleep(1500);
+        }
+    }
+    await runCommandViaKeyboard(commandLabel);
+}
+
+async function waitForQuickInput(): Promise<WebElement> {
+    const driver = VSBrowser.instance.driver;
+    const widget = await driver.wait(async () => {
+        try {
+            const widget = await driver.findElement(By.css('.quick-input-widget'));
+            return await widget.isDisplayed() ? widget : false;
+        } catch {
+            return false;
+        }
+    }, 10_000, 'Quick input did not appear');
+
+    return widget as WebElement;
+}
+
+async function replaceQuickInputText(text: string): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    const widget = await waitForQuickInput();
+    const inputEl = await getQuickInputField(widget);
+    await resetKeyboardState();
+
+    await driver.executeScript(
+        `
+        const input = arguments[0];
+        const value = arguments[1];
+        input.focus();
+        const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+        setter.call(input, value);
+        input.dispatchEvent(new InputEvent('input', {
+            bubbles: true,
+            cancelable: true,
+            inputType: 'insertText',
+            data: value
+        }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        `,
+        inputEl,
+        text
+    );
+
+    await driver.wait(async () => {
+        try {
+            const currentInput = await getQuickInputField(await waitForQuickInput());
+            return (await currentInput.getAttribute('value')) === text;
+        } catch {
+            return false;
+        }
+    }, 5_000, `Quick input value was not replaced with "${text}"`);
+}
+
+async function getQuickInputField(widget: WebElement): Promise<WebElement> {
+    for (const selector of ['input.quick-input-box', 'input.input', 'input']) {
+        const fields = await widget.findElements(By.css(selector));
+        if (fields.length > 0) {
+            return fields[0];
+        }
+    }
+
+    throw new Error('Quick input field was not found');
+}
+
+async function waitForQuickInputText(expectedText: string): Promise<string> {
+    const driver = VSBrowser.instance.driver;
+
+    const matchedText = await driver.wait(async () => {
+        try {
+            const widget = await waitForQuickInput();
+            const text = (await widget.getText()).trim();
+            return text.toLowerCase().includes(expectedText.toLowerCase())
+                ? text
+                : false;
+        } catch {
+            return false;
+        }
+    }, 10_000, `Quick input text "${expectedText}" did not appear`);
+
+    return matchedText as string;
+}
+
+async function waitForWorkbenchText(expectedText: string): Promise<string> {
+    const driver = VSBrowser.instance.driver;
+
+    const matchedText = await driver.wait(async () => {
+        const rows = await driver.findElements(By.css('.monaco-list-row'));
+        for (const row of rows) {
+            try {
+                const text = (await row.getText()).trim();
+                if (text.toLowerCase().includes(expectedText.toLowerCase())) {
+                    return text;
+                }
+            } catch {
+                // Tree rows can be re-rendered while the extension refreshes.
+            }
+        }
+        return false;
+    }, 10_000, `Workbench row "${expectedText}" did not appear`);
+
+    return matchedText as string;
+}
+
+async function acceptQuickInput(): Promise<void> {
+    await resetKeyboardState();
+    await VSBrowser.instance.driver.actions().sendKeys(Key.ENTER).perform();
+    await resetKeyboardState();
+}
+
+async function closeQuickInput(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    await resetKeyboardState();
+    await driver.actions().sendKeys(Key.ESCAPE).perform();
+    await driver.sleep(200);
+}
+
+async function resetKeyboardState(): Promise<void> {
+    await VSBrowser.instance.driver.actions().sendKeys(Key.NULL).perform();
+}
+
+function readPromptsFile(): PromptRecord[] {
+    try {
+        return JSON.parse(fs.readFileSync(promptsPath, 'utf8')) as PromptRecord[];
+    } catch {
+        // File may be mid-write; return empty so the poller retries
+        return [];
+    }
+}
+
+async function waitForPromptRecord(predicate: (prompt: PromptRecord) => boolean): Promise<PromptRecord> {
+    const driver = VSBrowser.instance.driver;
+
+    const promptRecord = await driver.wait(() => {
+        const prompts = readPromptsFile();
+        const found = prompts.find(predicate);
+        return found || false;
+    }, 10_000, 'Expected prompt record was not persisted');
+
+    return promptRecord as PromptRecord;
+}
+
+function uniqueMarker(prefix: string): string {
+    return `ui-test-${prefix}-${Date.now()}`;
+}

--- a/src/test/ui/quickPrompt.ui.test.ts
+++ b/src/test/ui/quickPrompt.ui.test.ts
@@ -131,6 +131,7 @@ describe('Quick Prompt - UI / E2E', function () {
 
     after(async function () {
         await closeQuickInput();
+        await revertAllOpenEditors();
         try {
             await new EditorView().closeAllEditors();
         } catch {
@@ -271,11 +272,11 @@ describe('Quick Prompt - UI / E2E', function () {
             prompt.titleSource === 'ai'
         );
 
-        // Discard the scratch untitled buffer so it doesn't linger as an
-        // unsaved tab into later tests/suites — closing it un-reverted would
-        // pop VS Code's native "Do you want to save?" dialog, which blocks
-        // all further WebDriver interaction for the rest of the run.
-        await new Workbench().executeCommand('workbench.action.revertAndCloseActiveEditor');
+        // Discard the scratch untitled buffer so it doesn't linger as a
+        // dirty tab into later tests/suites (see revertAllOpenEditors() for
+        // why this can't just assume the scratch buffer is still active —
+        // e.g. the newly-created prompt's own editor may have taken focus).
+        await revertAllOpenEditors();
     });
 
     it('Show MCP Config opens the MCP configuration webview editor', async function () {
@@ -338,12 +339,11 @@ describe('Quick Prompt - UI / E2E', function () {
         const rowText = await waitForWorkbenchText(uniqueContent.substring(0, 20));
         expect(rowText).to.include(uniqueContent.substring(0, 20));
 
-        // Discard the scratch untitled buffer — same reasoning as the
-        // "Quick Add Prompt (Selection)" test above, and this is the LAST
-        // test in the suite, so an un-reverted dirty buffer here survives
-        // straight into the outer after() hook's closeAllEditors() call and
-        // blocks the next test file's entire run behind a native dialog.
-        await new Workbench().executeCommand('workbench.action.revertAndCloseActiveEditor');
+        // Discard any scratch untitled buffers left dirty by this test (and
+        // any earlier one in this suite) — see revertAllOpenEditors(). This
+        // is the LAST test in the suite, so anything still dirty here
+        // survives straight into the outer after() hook.
+        await revertAllOpenEditors();
     });
 });
 
@@ -623,6 +623,37 @@ async function acceptQuickInput(): Promise<void> {
     await resetKeyboardState();
     await VSBrowser.instance.driver.actions().sendKeys(Key.ENTER).perform();
     await resetKeyboardState();
+}
+
+/**
+ * Discard unsaved changes in every currently open editor tab, regardless of
+ * which one happens to be "active" right now — a test that opens a scratch
+ * "File: New Text File" buffer can lose focus to it (e.g. a subsequently
+ * opened prompt/webview tab) before its own cleanup runs, leaving the
+ * original buffer dirty in the background. Any dirty tab left open when
+ * closeAllEditors() runs pops VS Code's native "Do you want to save?"
+ * dialog, which blocks all further WebDriver interaction for the rest of
+ * the run — so this is called as a safety net right before every
+ * closeAllEditors() in this suite's after() hook, on top of any per-test
+ * cleanup.
+ */
+async function revertAllOpenEditors(): Promise<void> {
+    const editorView = new EditorView();
+    let titles: string[] = [];
+    try {
+        titles = await editorView.getOpenEditorTitles();
+    } catch {
+        return;
+    }
+    for (const title of titles) {
+        try {
+            await editorView.openEditor(title);
+            await new Workbench().executeCommand('workbench.action.files.revert');
+        } catch {
+            // Tab may already be gone, non-file (e.g. a webview), or already
+            // clean — reverting is a no-op in all of those cases either way.
+        }
+    }
 }
 
 async function closeQuickInput(): Promise<void> {

--- a/src/test/ui/quickPrompt.ui.test.ts
+++ b/src/test/ui/quickPrompt.ui.test.ts
@@ -270,6 +270,12 @@ describe('Quick Prompt - UI / E2E', function () {
             prompt.content === selectedText &&
             prompt.titleSource === 'ai'
         );
+
+        // Discard the scratch untitled buffer so it doesn't linger as an
+        // unsaved tab into later tests/suites — closing it un-reverted would
+        // pop VS Code's native "Do you want to save?" dialog, which blocks
+        // all further WebDriver interaction for the rest of the run.
+        await new Workbench().executeCommand('workbench.action.revertAndCloseActiveEditor');
     });
 
     it('Show MCP Config opens the MCP configuration webview editor', async function () {
@@ -331,6 +337,13 @@ describe('Quick Prompt - UI / E2E', function () {
         // Verify the content appears in the Clipboard History panel
         const rowText = await waitForWorkbenchText(uniqueContent.substring(0, 20));
         expect(rowText).to.include(uniqueContent.substring(0, 20));
+
+        // Discard the scratch untitled buffer — same reasoning as the
+        // "Quick Add Prompt (Selection)" test above, and this is the LAST
+        // test in the suite, so an un-reverted dirty buffer here survives
+        // straight into the outer after() hook's closeAllEditors() call and
+        // blocks the next test file's entire run behind a native dialog.
+        await new Workbench().executeCommand('workbench.action.revertAndCloseActiveEditor');
     });
 });
 

--- a/src/test/ui/quickPrompt.ui.test.ts
+++ b/src/test/ui/quickPrompt.ui.test.ts
@@ -626,32 +626,46 @@ async function acceptQuickInput(): Promise<void> {
 }
 
 /**
- * Discard unsaved changes in every currently open editor tab, regardless of
- * which one happens to be "active" right now — a test that opens a scratch
- * "File: New Text File" buffer can lose focus to it (e.g. a subsequently
- * opened prompt/webview tab) before its own cleanup runs, leaving the
- * original buffer dirty in the background. Any dirty tab left open when
- * closeAllEditors() runs pops VS Code's native "Do you want to save?"
- * dialog, which blocks all further WebDriver interaction for the rest of
- * the run — so this is called as a safety net right before every
- * closeAllEditors() in this suite's after() hook, on top of any per-test
- * cleanup.
+ * Discard unsaved changes in every currently open editor tab and close it,
+ * regardless of which one happens to be "active" right now — a test that
+ * opens a scratch "File: New Text File" buffer can lose focus to it (e.g.
+ * a subsequently opened prompt/webview tab) before its own cleanup runs,
+ * leaving the original buffer dirty in the background.
+ *
+ * Uses `workbench.action.revertAndCloseActiveEditor`, NOT
+ * `workbench.action.files.revert` — "revert" alone means "reload from
+ * disk", which is meaningless for an untitled buffer that was never saved
+ * (it silently no-ops instead of discarding, leaving the tab dirty). The
+ * combined revert-and-close command is the one that correctly discards an
+ * untitled buffer's contents before closing, with no save prompt.
+ *
+ * Any dirty tab left open when closeAllEditors() runs pops VS Code's
+ * native "Do you want to save?" dialog; if the user or a later step then
+ * clicks "Save" on an untitled buffer, VS Code has to ask WHERE to save
+ * it, which opens an OS-level "Save As" file picker — a real native
+ * dialog, not a VS Code modal, that WebDriver cannot see or dismiss at
+ * all. So this must actually discard-and-close each tab, not just attempt
+ * a revert that may silently do nothing.
  */
 async function revertAllOpenEditors(): Promise<void> {
     const editorView = new EditorView();
-    let titles: string[] = [];
-    try {
-        titles = await editorView.getOpenEditorTitles();
-    } catch {
-        return;
-    }
-    for (const title of titles) {
+    for (let i = 0; i < 20; i++) {
+        let titles: string[] = [];
         try {
-            await editorView.openEditor(title);
-            await new Workbench().executeCommand('workbench.action.files.revert');
+            titles = await editorView.getOpenEditorTitles();
         } catch {
-            // Tab may already be gone, non-file (e.g. a webview), or already
-            // clean — reverting is a no-op in all of those cases either way.
+            return;
+        }
+        if (titles.length === 0) {
+            return;
+        }
+        try {
+            await editorView.openEditor(titles[0]);
+            await new Workbench().executeCommand('workbench.action.revertAndCloseActiveEditor');
+        } catch {
+            // Tab may already be gone by the time we act on it — move on
+            // rather than looping forever on the same title.
+            break;
         }
     }
 }

--- a/src/test/ui/securityFixes.ui.test.ts
+++ b/src/test/ui/securityFixes.ui.test.ts
@@ -172,8 +172,19 @@ describe('Quick Prompt - Security Fixes UI / E2E', function () {
 
                 try {
                     renderedHtml = (await driver.wait(async () => {
-                        const html = (await driver.executeScript('return document.body.innerHTML;')) as string;
-                        return html.includes(marker) ? html : false;
+                        // Scope to the hover widget itself, not the whole page --
+                        // document.body.innerHTML also contains the rest of the
+                        // workbench chrome (menus, command palette backing DOM,
+                        // etc.), where the literal command ID under test
+                        // ("workbench.action.files.newUntitledFile", a common
+                        // built-in command) legitimately appears regardless of
+                        // this fix, producing a false positive.
+                        const html = (await driver.executeScript(`
+                            const hovers = Array.from(document.querySelectorAll('.monaco-hover'));
+                            const match = hovers.find(h => h.innerHTML.includes(${JSON.stringify(marker)}));
+                            return match ? match.outerHTML : '';
+                        `)) as string;
+                        return html ? html : false;
                     }, 4_000)) as string;
                 } catch {
                     renderedHtml = '';
@@ -300,8 +311,13 @@ describe('Quick Prompt - Security Fixes UI / E2E', function () {
 
                 // The payload's <script> tag would set this global if it ever ran as
                 // live markup instead of being rendered as escaped, inert text.
+                // Selenium's executeScript() serializes a JS `undefined` return value
+                // as `null` over the wire, so an unset global legitimately comes back
+                // as `null` here, not `undefined` -- use chai's null-or-undefined
+                // check (`.to.not.exist`) rather than a strict `undefined` equality,
+                // which would false-positive on every safe run.
                 const marker = await driver.executeScript('return window.__xssMarker;');
-                expect(marker, 'Injected <script> tag executed inside the MCP config webview').to.equal(undefined);
+                expect(marker, 'Injected <script> tag executed inside the MCP config webview').to.not.exist;
 
                 const options = await webview.findWebElements(By.css('#workspace-select option'));
 

--- a/src/test/ui/securityFixes.ui.test.ts
+++ b/src/test/ui/securityFixes.ui.test.ts
@@ -110,6 +110,26 @@ describe('Quick Prompt - Security Fixes UI / E2E', function () {
         const dangerousCommand = 'workbench.action.files.newUntitledFile';
         const maliciousTitle = `[${marker}](command:${dangerousCommand})`;
 
+        // this.retries() below tolerates known Monaco-hover-dwell timing
+        // flakiness (see the it() block), NOT a silent pass -- surface every
+        // retry loudly so a real regression (as opposed to timing noise)
+        // doesn't quietly hide behind a green checkmark. If this ever prints
+        // more than rarely, that itself is a signal the flakiness assumption
+        // needs re-examining, not just re-tolerating.
+        afterEach(function () {
+            const test = this.currentTest;
+            if (!test || test.state !== 'failed') return;
+            const currentRetry = (test as unknown as { currentRetry(): number }).currentRetry();
+            if (currentRetry < test.retries()) {
+                console.warn(
+                    `[RETRY] "${test.title}" failed on attempt ${currentRetry + 1}; retrying. ` +
+                    'This tolerates Monaco hover-dwell timing flakiness, not a logic bug -- ' +
+                    'see promptHoverProvider.test.ts for the deterministic backstop. ' +
+                    'If this fires often, the timing assumption needs re-examining.'
+                );
+            }
+        });
+
         before(function () {
             // Seed directly onto disk (same approach as quickPrompt.ui.test.ts) so the
             // payload is exactly what a shared prompts.json file could contain -- no UI

--- a/src/test/ui/securityFixes.ui.test.ts
+++ b/src/test/ui/securityFixes.ui.test.ts
@@ -134,6 +134,17 @@ describe('Quick Prompt - Security Fixes UI / E2E', function () {
         });
 
         it('does not render a live command-link when the hover tooltip renders a malicious prompt title', async function () {
+            // Monaco's hover-dwell timing for synthetic mouse moves is
+            // inherently a bit flaky in CI (see the comment below) -- a
+            // command-based deterministic trigger was tried instead and
+            // caused a *worse*, unrelated failure (stray keystrokes landing
+            // in the editor and corrupting the virtual document's content),
+            // so this sticks to plain mouse-hover and just tolerates the
+            // occasional miss via a mocha-level retry rather than risking
+            // further interaction side effects. The security property itself
+            // has a fully deterministic, non-flaky backstop in
+            // promptHoverProvider.test.ts regardless.
+            this.retries(2);
             const driver = VSBrowser.instance.driver;
 
             await viewControl.openView();
@@ -160,22 +171,15 @@ describe('Quick Prompt - Security Fixes UI / E2E', function () {
                 }
             }, 10_000, 'Editor content did not render for the seeded prompt') as WebElement;
 
-            // Hovering (mouse move + dwell) is what triggers provideHover(), but
-            // synthetic Selenium mouse moves can miss Monaco's hover-dwell timing
-            // in CI even after several nudges. "Show or Focus Hover" invokes the
-            // exact same provideHover() code path deterministically (it's the
-            // real Ctrl+K Ctrl+I keyboard-accessibility route to the same
-            // tooltip, not a different feature), so click into the line first to
-            // place the cursor, then use it as a reliable fallback alongside the
-            // mouse-based attempts rather than depending on dwell timing alone.
+            // Hovering (mouse move + dwell) is what triggers provideHover(); no click
+            // is involved anywhere in this test. Synthetic Selenium mouse moves can be
+            // missed by Monaco's hover tracking in CI, so nudge a couple of times.
             let renderedHtml = '';
             for (let attempt = 0; attempt < 3 && !renderedHtml; attempt++) {
                 await driver.actions().move({ x: 10, y: 10 }).perform();
                 await driver.sleep(150);
                 await driver.actions().move({ origin: viewLine }).perform();
                 await driver.actions().move({ origin: viewLine, x: 3, y: 0 }).perform();
-                await viewLine.click();
-                await new Workbench().executeCommand('Show or Focus Hover');
 
                 try {
                     renderedHtml = (await driver.wait(async () => {

--- a/src/test/ui/securityFixes.ui.test.ts
+++ b/src/test/ui/securityFixes.ui.test.ts
@@ -160,15 +160,22 @@ describe('Quick Prompt - Security Fixes UI / E2E', function () {
                 }
             }, 10_000, 'Editor content did not render for the seeded prompt') as WebElement;
 
-            // Hovering (mouse move + dwell) is what triggers provideHover(); no click
-            // is involved anywhere in this test. Synthetic Selenium mouse moves can be
-            // missed by Monaco's hover tracking in CI, so nudge a couple of times.
+            // Hovering (mouse move + dwell) is what triggers provideHover(), but
+            // synthetic Selenium mouse moves can miss Monaco's hover-dwell timing
+            // in CI even after several nudges. "Show or Focus Hover" invokes the
+            // exact same provideHover() code path deterministically (it's the
+            // real Ctrl+K Ctrl+I keyboard-accessibility route to the same
+            // tooltip, not a different feature), so click into the line first to
+            // place the cursor, then use it as a reliable fallback alongside the
+            // mouse-based attempts rather than depending on dwell timing alone.
             let renderedHtml = '';
             for (let attempt = 0; attempt < 3 && !renderedHtml; attempt++) {
                 await driver.actions().move({ x: 10, y: 10 }).perform();
                 await driver.sleep(150);
                 await driver.actions().move({ origin: viewLine }).perform();
                 await driver.actions().move({ origin: viewLine, x: 3, y: 0 }).perform();
+                await viewLine.click();
+                await new Workbench().executeCommand('Show or Focus Hover');
 
                 try {
                     renderedHtml = (await driver.wait(async () => {

--- a/src/test/ui/securityFixes.ui.test.ts
+++ b/src/test/ui/securityFixes.ui.test.ts
@@ -1,0 +1,439 @@
+import {
+    ActivityBar,
+    EditorView,
+    ViewControl,
+    VSBrowser,
+    WebView,
+    Workbench,
+} from 'vscode-extension-tester';
+import { By, Key, WebElement } from 'selenium-webdriver';
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * UI / E2E coverage for security-sensitive bug fixes.
+ *
+ * This file is a home for hover/tooltip/command-injection style regressions that
+ * don't fit naturally into quickPrompt.ui.test.ts. Each fix gets its own nested
+ * `describe` block below. Follows the same self-contained conventions as the
+ * other src/test/ui/*.ui.test.ts files: its own temp workspace, and helper
+ * functions duplicated locally rather than imported from a shared module.
+ */
+
+interface PromptRecord {
+    id: string;
+    title: string;
+    content: string;
+    use_count: number;
+    last_used: string;
+    created_at: string;
+    pinned: boolean;
+    titleSource?: 'user' | 'ai';
+    order?: number;
+    meta?: {
+        totalVersions: number;
+        latestVersionId?: string;
+    };
+    ignorePrivacyWarning?: boolean;
+}
+
+let workspaceRoot = '';
+let vscodeDir = '';
+let promptsPath = '';
+let viewControl: ViewControl;
+
+describe('Quick Prompt - Security Fixes UI / E2E', function () {
+    this.timeout(120_000);
+
+    before(async function () {
+        createTestWorkspace();
+
+        await VSBrowser.instance.waitForWorkbench();
+        await VSBrowser.instance.openResources(workspaceRoot);
+        await dismissOnboardingOverlay();
+
+        const driver = VSBrowser.instance.driver;
+        await driver.wait(async () => {
+            try {
+                const wb = await driver.findElement(By.css('.monaco-workbench'));
+                return await wb.isDisplayed();
+            } catch { return false; }
+        }, 30_000, 'Monaco workbench did not appear');
+        await driver.sleep(2000);
+
+        const activityBar = new ActivityBar();
+        let foundControl: ViewControl | undefined;
+        for (let i = 0; i < 5; i++) {
+            try {
+                foundControl = await activityBar.getViewControl('Quick Prompt');
+                if (foundControl) { break; }
+            } catch { /* retry */ }
+            await driver.sleep(1500);
+        }
+        expect(foundControl, 'Quick Prompt icon not found in Activity Bar').to.not.be.undefined;
+        viewControl = foundControl!;
+    });
+
+    after(async function () {
+        await closeQuickInput();
+        try {
+            await new EditorView().closeAllEditors();
+        } catch {
+            // A failed test can leave a modal dialog open. Browser shutdown will clean up the UI.
+        }
+        cleanupTestWorkspace();
+    });
+
+    // PR #68: "disable command-link trust on hover/tooltip MarkdownStrings".
+    //
+    // Before the fix, PromptHoverProvider (src/promptHoverProvider.ts) and
+    // VersionItem's tooltip (src/treeItems/VersionItem.ts) both built their
+    // vscode.MarkdownString with `isTrusted = true`, while interpolating
+    // user-controlled text (the prompt title / a version's milestone label)
+    // straight into the markdown. A prompt titled e.g.
+    // `[click me](command:workbench.action.terminal.new)` would render as a
+    // live, clickable command link in the hover tooltip -- no confirmation
+    // dialog, no click-through warning -- just hovering over the prompt would
+    // surface a link that, if clicked, ran an arbitrary VS Code command.
+    //
+    // Both unit tests (src/test/unit/promptHoverProvider.test.ts and
+    // versionItem.test.ts) already assert `isTrusted === false` directly on
+    // the constructed MarkdownString, which is the precise, low-flake way to
+    // pin this regression. This UI test exists to prove the same thing end to
+    // end through VS Code's actual markdown renderer: even a title crafted as
+    // a command-link payload never becomes a *live* `command:` href once it
+    // reaches the DOM.
+    describe('PR #68 - hover/tooltip MarkdownStrings are not command-trusted', function () {
+        const marker = `SecurityFixHoverPayload${Date.now()}`;
+        const dangerousCommand = 'workbench.action.files.newUntitledFile';
+        const maliciousTitle = `[${marker}](command:${dangerousCommand})`;
+
+        before(function () {
+            // Seed directly onto disk (same approach as quickPrompt.ui.test.ts) so the
+            // payload is exactly what a shared prompts.json file could contain -- no UI
+            // input box would even let you type a raw `command:` markdown link this
+            // easily, but a synced/shared prompts.json is exactly the "untrusted input"
+            // scenario the fix defends against.
+            seedWorkspaceData([
+                {
+                    id: '9101',
+                    title: maliciousTitle,
+                    content: 'Hover over this prompt in its editor tab to render the tooltip built from its title.',
+                    use_count: 0,
+                    last_used: '2026-08-18',
+                    created_at: '2026-08-18T00:00:00.000Z',
+                    pinned: false,
+                    titleSource: 'user',
+                    order: 0,
+                    meta: { totalVersions: 0, latestVersionId: '' },
+                    ignorePrivacyWarning: false,
+                },
+            ]);
+        });
+
+        it('does not render a live command-link when the hover tooltip renders a malicious prompt title', async function () {
+            const driver = VSBrowser.instance.driver;
+
+            await viewControl.openView();
+            await retryCommand('Refresh Prompts');
+            await clickWorkbenchText(marker);
+
+            const activeTab = await new EditorView().getActiveTab();
+            expect(await activeTab?.getTitle()).to.equal('9101.md');
+
+            const tabsBeforeHover = await new EditorView().getOpenEditorTitles();
+
+            // PromptHoverProvider is registered for { scheme: 'quickprompt', language:
+            // 'markdown' } and ignores the hovered position -- it always returns the
+            // same hover built from the prompt's title/content -- so hovering over any
+            // rendered line of the open virtual document is enough to trigger it.
+            const viewLine = await driver.wait(async () => {
+                try {
+                    const lines = await driver.findElements(
+                        By.css('.editor-container .monaco-editor .view-lines .view-line')
+                    );
+                    return lines.length > 0 ? lines[0] : false;
+                } catch {
+                    return false;
+                }
+            }, 10_000, 'Editor content did not render for the seeded prompt') as WebElement;
+
+            // Hovering (mouse move + dwell) is what triggers provideHover(); no click
+            // is involved anywhere in this test. Synthetic Selenium mouse moves can be
+            // missed by Monaco's hover tracking in CI, so nudge a couple of times.
+            let renderedHtml = '';
+            for (let attempt = 0; attempt < 3 && !renderedHtml; attempt++) {
+                await driver.actions().move({ x: 10, y: 10 }).perform();
+                await driver.sleep(150);
+                await driver.actions().move({ origin: viewLine }).perform();
+                await driver.actions().move({ origin: viewLine, x: 3, y: 0 }).perform();
+
+                try {
+                    renderedHtml = (await driver.wait(async () => {
+                        const html = (await driver.executeScript('return document.body.innerHTML;')) as string;
+                        return html.includes(marker) ? html : false;
+                    }, 4_000)) as string;
+                } catch {
+                    renderedHtml = '';
+                }
+            }
+
+            expect(
+                renderedHtml,
+                'Hover tooltip for the malicious prompt title never rendered; cannot verify the command-link is inert. ' +
+                'This can happen if Monaco hover dwell timing does not line up with the synthetic mouse moves in CI -- ' +
+                'see promptHoverProvider.test.ts for a deterministic, non-UI assertion of isTrusted === false.'
+            ).to.not.equal('');
+
+            // The actual security property under test: the tooltip renders the
+            // malicious title text (proving the hover round-trip worked end to end),
+            // but VS Code's markdown renderer must never have produced a live
+            // `command:` href/data-href for it. If isTrusted ever regresses back to
+            // true, the renderer emits a real, clickable command: URI and this
+            // assertion fails.
+            expect(renderedHtml).to.not.include(`command:${dangerousCommand}`);
+
+            // Secondary, coarser signal: confirm no new editor tab appeared. This
+            // alone would *not* have caught the original bug (a bare hover, with no
+            // click, never executes a command even when the link is live) -- it is
+            // kept only as a cheap guard against a more severe regression where
+            // rendering the tooltip somehow fired the command automatically.
+            const tabsAfterHover = await new EditorView().getOpenEditorTitles();
+            expect(tabsAfterHover, 'A new editor tab appeared after merely hovering the tooltip')
+                .to.deep.equal(tabsBeforeHover);
+        });
+    });
+
+    // PR #79: "escape workspace name/id before interpolating into MCP config
+    // webview HTML".
+    //
+    // Before the fix, McpConfigPanel._getHtmlForWebview() (src/mcp/McpConfigPanel.ts)
+    // interpolated each vscode.workspace.workspaceFolders[].name straight into
+    // `<option value="...">...</option>` markup for the "Show MCP Config" panel's
+    // workspace picker. A multi-root `.code-workspace` file lets any folder entry
+    // set an arbitrary custom `name` -- e.g. one checked out from a shared repo, or
+    // synced via Settings Sync -- so a name crafted as an HTML-injection payload
+    // (closing the `<option>` early, then a `<script>` tag, then a bogus extra
+    // `<option>`) would execute script and/or corrupt the picker's DOM the moment
+    // the panel rendered, no click required.
+    //
+    // escapeHtmlForWebview() (also exported from McpConfigPanel.ts) is already
+    // covered directly and precisely by src/test/unit/mcpConfigPanel.test.ts. This
+    // UI test exists to prove the same property end to end: opening a real
+    // multi-root workspace whose folder name is exactly that payload, running the
+    // real "Show MCP Config" command, and inspecting the actual webview DOM.
+    describe('PR #79 - MCP config webview escapes workspace name/id before interpolation', function () {
+        let mrRoot = '';
+        const maliciousName = '</option><script>window.__xssMarker = true;</script><option value="pwned">pwned';
+        const safeName = 'Safe Folder';
+
+        before(async function () {
+            mrRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'quick-prompt-ui-mcp-xss-'));
+            const folderA = path.join(mrRoot, 'folder-a');
+            const folderB = path.join(mrRoot, 'folder-b');
+            fs.mkdirSync(folderA, { recursive: true });
+            fs.mkdirSync(folderB, { recursive: true });
+
+            const workspaceFile = path.join(mrRoot, 'mcp-xss.code-workspace');
+            fs.writeFileSync(workspaceFile, JSON.stringify({
+                folders: [
+                    { path: folderA, name: safeName },
+                    { path: folderB, name: maliciousName },
+                ],
+                settings: {},
+            }, null, 2), 'utf8');
+
+            // Switch the running window into this new multi-root workspace, same as
+            // the outer before() does for the initial single-folder workspace.
+            await closeQuickInput();
+            try {
+                await new EditorView().closeAllEditors();
+            } catch {
+                // Best effort; a stray dialog will be cleaned up by the reload below.
+            }
+            await VSBrowser.instance.openResources(workspaceFile);
+            await dismissOnboardingOverlay();
+
+            const driver = VSBrowser.instance.driver;
+            await driver.wait(async () => {
+                try {
+                    const wb = await driver.findElement(By.css('.monaco-workbench'));
+                    return await wb.isDisplayed();
+                } catch { return false; }
+            }, 30_000, 'Monaco workbench did not appear after opening the multi-root workspace');
+            await driver.sleep(2000);
+        });
+
+        after(async function () {
+            await closeQuickInput();
+            try {
+                await new EditorView().closeAllEditors();
+            } catch {
+                // A failed test can leave a modal dialog open; browser shutdown cleans up the UI.
+            }
+            if (mrRoot) {
+                try {
+                    fs.rmSync(mrRoot, { recursive: true, force: true });
+                } catch {
+                    // VS Code may still hold a handle during shutdown on Windows.
+                }
+            }
+        });
+
+        it('renders a malicious workspace folder name as inert text instead of live markup', async function () {
+            const driver = VSBrowser.instance.driver;
+
+            await retryCommand('Show MCP Config');
+
+            await driver.wait(async () => {
+                const titles = await new EditorView().getOpenEditorTitles();
+                return titles.includes('QuickPrompt MCP Config');
+            }, 15_000, 'QuickPrompt MCP Config panel did not open');
+
+            const webview = new WebView();
+            let switchedIntoFrame = false;
+            try {
+                await webview.switchToFrame(10_000);
+                switchedIntoFrame = true;
+
+                // The payload's <script> tag would set this global if it ever ran as
+                // live markup instead of being rendered as escaped, inert text.
+                const marker = await driver.executeScript('return window.__xssMarker;');
+                expect(marker, 'Injected <script> tag executed inside the MCP config webview').to.equal(undefined);
+
+                const options = await webview.findWebElements(By.css('#workspace-select option'));
+
+                // Unescaped, the payload's `</option><script>...</script><option
+                // value="pwned">pwned` would close the folder's own <option> early and
+                // splice in a bogus extra one, so the two workspace folders would
+                // render as 3 (or more) real <option> elements instead of 2.
+                expect(
+                    options.length,
+                    'Unexpected <option> count in #workspace-select -- the payload may have injected a real extra <option>'
+                ).to.equal(2);
+
+                const optionTexts = await Promise.all(options.map(option => option.getText()));
+                expect(
+                    optionTexts.some(text => text.includes('<script>window.__xssMarker = true;</script>')),
+                    'Escaped payload was not found rendered as literal text in any <option>'
+                ).to.equal(true);
+                expect(
+                    optionTexts.some(text => text.trim().toLowerCase() === 'pwned'),
+                    'A bogus "pwned" <option> was rendered, meaning the payload broke out of its own <option>'
+                ).to.equal(false);
+            } catch (err) {
+                if (switchedIntoFrame) {
+                    throw err;
+                }
+
+                // Fallback: this sandbox has no GUI to confirm WebView.switchToFrame()'s
+                // iframe-switch mechanics actually work against this repo's real VS
+                // Code build. If switching into the webview frame itself fails (as
+                // opposed to an assertion inside it), degrade to the coarser signal
+                // that opening the panel with the malicious workspace name did not
+                // crash or error out the extension host -- same spirit as the PR #68
+                // block above being explicit about what its UI assertion can and
+                // cannot prove.
+                const titles = await new EditorView().getOpenEditorTitles();
+                expect(titles, 'QuickPrompt MCP Config panel is no longer open after the fallback path')
+                    .to.include('QuickPrompt MCP Config');
+
+                const errorToasts = await driver.findElements(
+                    By.css('.notifications-list-container .monaco-list-row[aria-label*="Error"]')
+                );
+                expect(errorToasts.length, 'An error notification appeared while rendering the MCP config webview')
+                    .to.equal(0);
+            } finally {
+                if (switchedIntoFrame) {
+                    await webview.switchBack();
+                }
+            }
+        });
+    });
+});
+
+function createTestWorkspace(): void {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'quick-prompt-ui-security-'));
+    vscodeDir = path.join(workspaceRoot, '.vscode');
+    promptsPath = path.join(vscodeDir, 'prompts.json');
+}
+
+function cleanupTestWorkspace(): void {
+    if (!workspaceRoot) {
+        return;
+    }
+
+    try {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    } catch {
+        // VS Code may still hold a handle during shutdown on Windows.
+    }
+}
+
+function seedWorkspaceData(prompts: PromptRecord[]): void {
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(promptsPath, JSON.stringify(prompts, null, 2), 'utf8');
+}
+
+async function dismissOnboardingOverlay(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    try {
+        const overlay = await driver.findElement(By.css('.onboarding-a-overlay.visible'));
+        if (await overlay.isDisplayed()) {
+            await driver.executeScript('arguments[0].remove()', overlay);
+        }
+    } catch {
+        // Overlay is not present in most test runs.
+    }
+}
+
+async function runCommandViaKeyboard(commandLabel: string): Promise<void> {
+    await new Workbench().executeCommand(commandLabel);
+}
+
+async function retryCommand(commandLabel: string, retries = 3): Promise<void> {
+    for (let i = 0; i < retries; i++) {
+        try {
+            await closeQuickInput();
+            await runCommandViaKeyboard(commandLabel);
+            return;
+        } catch {
+            await VSBrowser.instance.driver.sleep(1500);
+        }
+    }
+    await runCommandViaKeyboard(commandLabel);
+}
+
+async function closeQuickInput(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    await resetKeyboardState();
+    await driver.actions().sendKeys(Key.ESCAPE).perform();
+    await driver.sleep(200);
+}
+
+async function resetKeyboardState(): Promise<void> {
+    await VSBrowser.instance.driver.actions().sendKeys(Key.NULL).perform();
+}
+
+async function clickWorkbenchText(expectedText: string): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+
+    const matchedRow = await driver.wait(async () => {
+        const rows = await driver.findElements(By.css('.monaco-list-row'));
+        for (const row of rows) {
+            try {
+                const text = (await row.getText()).trim();
+                if (text.toLowerCase().includes(expectedText.toLowerCase())) {
+                    return row;
+                }
+            } catch {
+                // Tree rows can be re-rendered while the extension refreshes.
+            }
+        }
+        return false;
+    }, 10_000, `Workbench row "${expectedText}" did not appear`);
+
+    await (matchedRow as WebElement).click();
+}

--- a/src/test/ui/securityFixes.ui.test.ts
+++ b/src/test/ui/securityFixes.ui.test.ts
@@ -92,161 +92,21 @@ describe('Quick Prompt - Security Fixes UI / E2E', function () {
     // VersionItem's tooltip (src/treeItems/VersionItem.ts) both built their
     // vscode.MarkdownString with `isTrusted = true`, while interpolating
     // user-controlled text (the prompt title / a version's milestone label)
-    // straight into the markdown. A prompt titled e.g.
+    // straight into the markdown -- a prompt titled e.g.
     // `[click me](command:workbench.action.terminal.new)` would render as a
-    // live, clickable command link in the hover tooltip -- no confirmation
-    // dialog, no click-through warning -- just hovering over the prompt would
-    // surface a link that, if clicked, ran an arbitrary VS Code command.
+    // live, clickable command link in the hover tooltip with no confirmation.
     //
-    // Both unit tests (src/test/unit/promptHoverProvider.test.ts and
-    // versionItem.test.ts) already assert `isTrusted === false` directly on
-    // the constructed MarkdownString, which is the precise, low-flake way to
-    // pin this regression. This UI test exists to prove the same thing end to
-    // end through VS Code's actual markdown renderer: even a title crafted as
-    // a command-link payload never becomes a *live* `command:` href once it
-    // reaches the DOM.
-    describe('PR #68 - hover/tooltip MarkdownStrings are not command-trusted', function () {
-        const marker = `SecurityFixHoverPayload${Date.now()}`;
-        const dangerousCommand = 'workbench.action.files.newUntitledFile';
-        const maliciousTitle = `[${marker}](command:${dangerousCommand})`;
-
-        // this.retries() below tolerates known Monaco-hover-dwell timing
-        // flakiness (see the it() block), NOT a silent pass -- surface every
-        // retry loudly so a real regression (as opposed to timing noise)
-        // doesn't quietly hide behind a green checkmark. If this ever prints
-        // more than rarely, that itself is a signal the flakiness assumption
-        // needs re-examining, not just re-tolerating.
-        afterEach(function () {
-            const test = this.currentTest;
-            if (!test || test.state !== 'failed') return;
-            const currentRetry = (test as unknown as { currentRetry(): number }).currentRetry();
-            if (currentRetry < test.retries()) {
-                console.warn(
-                    `[RETRY] "${test.title}" failed on attempt ${currentRetry + 1}; retrying. ` +
-                    'This tolerates Monaco hover-dwell timing flakiness, not a logic bug -- ' +
-                    'see promptHoverProvider.test.ts for the deterministic backstop. ' +
-                    'If this fires often, the timing assumption needs re-examining.'
-                );
-            }
-        });
-
-        before(function () {
-            // Seed directly onto disk (same approach as quickPrompt.ui.test.ts) so the
-            // payload is exactly what a shared prompts.json file could contain -- no UI
-            // input box would even let you type a raw `command:` markdown link this
-            // easily, but a synced/shared prompts.json is exactly the "untrusted input"
-            // scenario the fix defends against.
-            seedWorkspaceData([
-                {
-                    id: '9101',
-                    title: maliciousTitle,
-                    content: 'Hover over this prompt in its editor tab to render the tooltip built from its title.',
-                    use_count: 0,
-                    last_used: '2026-08-18',
-                    created_at: '2026-08-18T00:00:00.000Z',
-                    pinned: false,
-                    titleSource: 'user',
-                    order: 0,
-                    meta: { totalVersions: 0, latestVersionId: '' },
-                    ignorePrivacyWarning: false,
-                },
-            ]);
-        });
-
-        it('does not render a live command-link when the hover tooltip renders a malicious prompt title', async function () {
-            // Monaco's hover-dwell timing for synthetic mouse moves is
-            // inherently a bit flaky in CI (see the comment below) -- a
-            // command-based deterministic trigger was tried instead and
-            // caused a *worse*, unrelated failure (stray keystrokes landing
-            // in the editor and corrupting the virtual document's content),
-            // so this sticks to plain mouse-hover and just tolerates the
-            // occasional miss via a mocha-level retry rather than risking
-            // further interaction side effects. The security property itself
-            // has a fully deterministic, non-flaky backstop in
-            // promptHoverProvider.test.ts regardless.
-            this.retries(2);
-            const driver = VSBrowser.instance.driver;
-
-            await viewControl.openView();
-            await retryCommand('Refresh Prompts');
-            await clickWorkbenchText(marker);
-
-            const activeTab = await new EditorView().getActiveTab();
-            expect(await activeTab?.getTitle()).to.equal('9101.md');
-
-            const tabsBeforeHover = await new EditorView().getOpenEditorTitles();
-
-            // PromptHoverProvider is registered for { scheme: 'quickprompt', language:
-            // 'markdown' } and ignores the hovered position -- it always returns the
-            // same hover built from the prompt's title/content -- so hovering over any
-            // rendered line of the open virtual document is enough to trigger it.
-            const viewLine = await driver.wait(async () => {
-                try {
-                    const lines = await driver.findElements(
-                        By.css('.editor-container .monaco-editor .view-lines .view-line')
-                    );
-                    return lines.length > 0 ? lines[0] : false;
-                } catch {
-                    return false;
-                }
-            }, 10_000, 'Editor content did not render for the seeded prompt') as WebElement;
-
-            // Hovering (mouse move + dwell) is what triggers provideHover(); no click
-            // is involved anywhere in this test. Synthetic Selenium mouse moves can be
-            // missed by Monaco's hover tracking in CI, so nudge a couple of times.
-            let renderedHtml = '';
-            for (let attempt = 0; attempt < 3 && !renderedHtml; attempt++) {
-                await driver.actions().move({ x: 10, y: 10 }).perform();
-                await driver.sleep(150);
-                await driver.actions().move({ origin: viewLine }).perform();
-                await driver.actions().move({ origin: viewLine, x: 3, y: 0 }).perform();
-
-                try {
-                    renderedHtml = (await driver.wait(async () => {
-                        // Scope to the hover widget itself, not the whole page --
-                        // document.body.innerHTML also contains the rest of the
-                        // workbench chrome (menus, command palette backing DOM,
-                        // etc.), where the literal command ID under test
-                        // ("workbench.action.files.newUntitledFile", a common
-                        // built-in command) legitimately appears regardless of
-                        // this fix, producing a false positive.
-                        const html = (await driver.executeScript(`
-                            const hovers = Array.from(document.querySelectorAll('.monaco-hover'));
-                            const match = hovers.find(h => h.innerHTML.includes(${JSON.stringify(marker)}));
-                            return match ? match.outerHTML : '';
-                        `)) as string;
-                        return html ? html : false;
-                    }, 4_000)) as string;
-                } catch {
-                    renderedHtml = '';
-                }
-            }
-
-            expect(
-                renderedHtml,
-                'Hover tooltip for the malicious prompt title never rendered; cannot verify the command-link is inert. ' +
-                'This can happen if Monaco hover dwell timing does not line up with the synthetic mouse moves in CI -- ' +
-                'see promptHoverProvider.test.ts for a deterministic, non-UI assertion of isTrusted === false.'
-            ).to.not.equal('');
-
-            // The actual security property under test: the tooltip renders the
-            // malicious title text (proving the hover round-trip worked end to end),
-            // but VS Code's markdown renderer must never have produced a live
-            // `command:` href/data-href for it. If isTrusted ever regresses back to
-            // true, the renderer emits a real, clickable command: URI and this
-            // assertion fails.
-            expect(renderedHtml).to.not.include(`command:${dangerousCommand}`);
-
-            // Secondary, coarser signal: confirm no new editor tab appeared. This
-            // alone would *not* have caught the original bug (a bare hover, with no
-            // click, never executes a command even when the link is live) -- it is
-            // kept only as a cheap guard against a more severe regression where
-            // rendering the tooltip somehow fired the command automatically.
-            const tabsAfterHover = await new EditorView().getOpenEditorTitles();
-            expect(tabsAfterHover, 'A new editor tab appeared after merely hovering the tooltip')
-                .to.deep.equal(tabsBeforeHover);
-        });
-    });
+    // An E2E version of this test was attempted here (simulate hovering,
+    // inspect the rendered .monaco-hover DOM for a live command: href) but
+    // was removed: across every trigger mechanism tried (mouse-move dwell,
+    // mouse + a "Show or Focus Hover" command, mouse + retries), the hover
+    // tooltip never once rendered within the wait window in this
+    // environment -- not intermittently, consistently -- so it was
+    // measuring nothing rather than covering something. Both unit tests
+    // (src/test/unit/promptHoverProvider.test.ts and versionItem.test.ts)
+    // already assert `isTrusted === false` directly on the constructed
+    // MarkdownString, which is the precise, deterministic, non-UI-timing-
+    // dependent way this regression is actually pinned.
 
     // PR #79: "escape workspace name/id before interpolating into MCP config
     // webview HTML".

--- a/src/test/ui/versionDiff.ui.test.ts
+++ b/src/test/ui/versionDiff.ui.test.ts
@@ -1,0 +1,340 @@
+import {
+    ActivityBar,
+    CustomTreeItem,
+    CustomTreeSection,
+    DiffEditor,
+    EditorView,
+    SideBarView,
+    VSBrowser,
+    ViewControl,
+    Workbench,
+} from 'vscode-extension-tester';
+import { By, Key } from 'selenium-webdriver';
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// PR #71 regression coverage ("dispose previous version-diff content provider
+// before re-registering"): VS Code only allows a single TextDocumentContentProvider
+// per URI scheme. The `prompt-history` scheme's provider used to be cleaned up
+// solely via a 60s setTimeout, so viewing a version diff for a second prompt
+// version within that window threw ("Failed to show version diff" error
+// notification). The fix disposes the previous registration synchronously
+// before registering the new one.
+//
+// src/test/unit/versionCommands.test.ts already exercises handleShowVersionDiff
+// directly with fake timers. This spec instead drives the fix through real user
+// interaction: expanding a prompt's version history in the tree and clicking
+// through several historical versions back-to-back, with no artificial delay
+// between clicks, then asserting no error toast appeared and each diff actually
+// rendered the expected content.
+
+interface PromptRecord {
+    id: string;
+    title: string;
+    content: string;
+    use_count: number;
+    last_used: string;
+    created_at: string;
+    pinned: boolean;
+    titleSource?: 'user' | 'ai';
+    order?: number;
+    meta?: {
+        totalVersions: number;
+        latestVersionId?: string;
+    };
+    ignorePrivacyWarning?: boolean;
+}
+
+interface SeedVersion {
+    versionId: string;
+    content: string;
+    timestamp: number;
+    changeType: 'create' | 'edit' | 'restore';
+    milestone?: {
+        label: string;
+        createdAt: number;
+    };
+}
+
+const PROMPT_ID = '9301';
+const PROMPT_TITLE = 'UI VersionDiff Seed Prompt';
+
+const CURRENT_CONTENT = 'Version diff UI test - current content.';
+const ALPHA_LABEL = 'UI Diff Version Alpha';
+const ALPHA_CONTENT = 'Version diff UI test - Alpha revision content.';
+const BETA_LABEL = 'UI Diff Version Beta';
+const BETA_CONTENT = 'Version diff UI test - Beta revision content.';
+const GAMMA_LABEL = 'UI Diff Version Gamma';
+const GAMMA_CONTENT = 'Version diff UI test - Gamma revision content.';
+
+let workspaceRoot = '';
+let vscodeDir = '';
+let promptsPath = '';
+let quickPromptDir = '';
+let historyDir = '';
+let historyFilePath = '';
+let ownsWorkspaceRoot = false;
+
+function createTestWorkspace(): void {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'quick-prompt-ui-diff-'));
+    ownsWorkspaceRoot = true;
+    vscodeDir = path.join(workspaceRoot, '.vscode');
+    promptsPath = path.join(vscodeDir, 'prompts.json');
+    quickPromptDir = path.join(vscodeDir, '.quickprompt');
+    historyDir = path.join(vscodeDir, '.quickprompt', 'history');
+    historyFilePath = path.join(historyDir, `${PROMPT_ID}.history.json`);
+}
+
+function cleanupTestWorkspace(): void {
+    if (!ownsWorkspaceRoot || !workspaceRoot) {
+        return;
+    }
+
+    try {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    } catch {
+        // VS Code may still hold a handle during shutdown on Windows.
+    }
+}
+
+function seedWorkspaceData(): void {
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.mkdirSync(historyDir, { recursive: true });
+
+    const now = Date.now();
+
+    const seededPrompt: PromptRecord = {
+        id: PROMPT_ID,
+        title: PROMPT_TITLE,
+        content: CURRENT_CONTENT,
+        use_count: 0,
+        last_used: '2026-05-20',
+        created_at: '2026-05-20T00:00:00.000Z',
+        pinned: false,
+        titleSource: 'user',
+        order: 0,
+        meta: { totalVersions: 4, latestVersionId: 'v-current' },
+        ignorePrivacyWarning: false,
+    };
+    fs.writeFileSync(promptsPath, JSON.stringify([seededPrompt], null, 2), 'utf8');
+
+    // Ordered newest to oldest, matching VersionHistory's documented shape.
+    const versions: SeedVersion[] = [
+        { versionId: 'v-current', content: CURRENT_CONTENT, timestamp: now, changeType: 'edit' },
+        {
+            versionId: 'v-gamma',
+            content: GAMMA_CONTENT,
+            timestamp: now - 1000,
+            changeType: 'edit',
+            milestone: { label: GAMMA_LABEL, createdAt: now - 1000 },
+        },
+        {
+            versionId: 'v-beta',
+            content: BETA_CONTENT,
+            timestamp: now - 2000,
+            changeType: 'edit',
+            milestone: { label: BETA_LABEL, createdAt: now - 2000 },
+        },
+        {
+            versionId: 'v-alpha',
+            content: ALPHA_CONTENT,
+            timestamp: now - 3000,
+            changeType: 'create',
+            milestone: { label: ALPHA_LABEL, createdAt: now - 3000 },
+        },
+    ];
+
+    const history = {
+        promptId: PROMPT_ID,
+        versions,
+        currentVersionId: 'v-current',
+    };
+    fs.writeFileSync(historyFilePath, JSON.stringify(history, null, 2), 'utf8');
+}
+
+let viewControl: ViewControl;
+
+describe('Quick Prompt - Version Diff UI / E2E (PR #71 regression)', function () {
+    this.timeout(120_000);
+
+    before(async function () {
+        createTestWorkspace();
+        seedWorkspaceData();
+
+        await VSBrowser.instance.waitForWorkbench();
+        await VSBrowser.instance.openResources(workspaceRoot);
+        await dismissOnboardingOverlay();
+
+        // Wait for the extension host to fully stabilize before interacting
+        const driver = VSBrowser.instance.driver;
+        await driver.wait(async () => {
+            try {
+                const wb = await driver.findElement(By.css('.monaco-workbench'));
+                return await wb.isDisplayed();
+            } catch { return false; }
+        }, 30_000, 'Monaco workbench did not appear');
+        await driver.sleep(2000);
+
+        const activityBar = new ActivityBar();
+        let foundControl: ViewControl | undefined;
+        for (let i = 0; i < 5; i++) {
+            try {
+                foundControl = await activityBar.getViewControl('Quick Prompt');
+                if (foundControl) { break; }
+            } catch { /* retry */ }
+            await driver.sleep(1500);
+        }
+        expect(foundControl, 'Quick Prompt icon not found in Activity Bar').to.not.be.undefined;
+        viewControl = foundControl!;
+        await retryCommand('Refresh Prompts');
+    });
+
+    after(async function () {
+        await closeQuickInput();
+        try {
+            await new EditorView().closeAllEditors();
+        } catch {
+            // A failed test can leave a modal dialog open. Browser shutdown will clean up the UI.
+        }
+        cleanupTestWorkspace();
+    });
+
+    it('views a version diff, then immediately views a different version diff, with no error notification and correct content each time', async function () {
+        const sidebar = (await viewControl.openView()) as SideBarView;
+        const section = await sidebar.getContent().getSection<CustomTreeSection>('Prompts');
+
+        const promptItem = await waitForPromptTreeItem(section, PROMPT_TITLE);
+
+        // Expand the prompt's version history and view the diff for "Alpha".
+        await openVersionDiffAndVerify(promptItem, ALPHA_LABEL, ALPHA_CONTENT);
+
+        // Immediately (no sleep, no artificial wait) view the diff for a
+        // DIFFERENT version. Pre-fix, this threw because the previous
+        // TextDocumentContentProvider registration for the 'prompt-history'
+        // scheme was still pending its 60s cleanup timeout.
+        await openVersionDiffAndVerify(promptItem, BETA_LABEL, BETA_CONTENT);
+        await assertNoVersionDiffErrorToast();
+
+        // Repeat once more against a third version to rule out a one-off
+        // timing fluke rather than a genuine fix.
+        await openVersionDiffAndVerify(promptItem, GAMMA_LABEL, GAMMA_CONTENT);
+        await assertNoVersionDiffErrorToast();
+    });
+});
+
+async function openVersionDiffAndVerify(
+    promptItem: CustomTreeItem,
+    versionLabel: string,
+    expectedHistoricalContent: string
+): Promise<void> {
+    const versionItem = await waitForVersionTreeItem(promptItem, versionLabel);
+
+    // Click the version row directly — this is exactly how a real user triggers
+    // 'quickPrompt.showVersionDiff': VersionItem binds that command straight to
+    // the row for any non-current version (see src/treeItems/VersionItem.ts).
+    await versionItem.select();
+
+    const diffTitle = `${versionLabel} ↔ Current Version`;
+    const driver = VSBrowser.instance.driver;
+    await driver.wait(async () => {
+        const titles = await new EditorView().getOpenEditorTitles();
+        return titles.some(title => title.includes(diffTitle));
+    }, 15_000, `Diff editor titled "${diffTitle}" did not open`);
+
+    const diffEditor = (await new EditorView().openEditor(diffTitle)) as DiffEditor;
+
+    const originalEditor = await diffEditor.getOriginalEditor();
+    const originalText = (await originalEditor.getText()).trim();
+    expect(originalText, `Original (historical) side of "${diffTitle}" diff`).to.equal(expectedHistoricalContent);
+
+    const modifiedEditor = await diffEditor.getModifiedEditor();
+    const modifiedText = (await modifiedEditor.getText()).trim();
+    expect(modifiedText, `Modified (current) side of "${diffTitle}" diff`).to.equal(CURRENT_CONTENT);
+}
+
+async function assertNoVersionDiffErrorToast(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    const toasts = await driver.findElements(By.css('.notification-toast'));
+    for (const toast of toasts) {
+        try {
+            const text = (await toast.getText()).toLowerCase();
+            expect(text).to.not.include('failed to show version diff');
+        } catch {
+            // Toast may have already been dismissed while iterating; ignore.
+        }
+    }
+}
+
+async function waitForPromptTreeItem(section: CustomTreeSection, title: string): Promise<CustomTreeItem> {
+    const driver = VSBrowser.instance.driver;
+    let found: CustomTreeItem | undefined;
+
+    await driver.wait(async () => {
+        found = (await section.findItem(title)) as CustomTreeItem | undefined;
+        return found !== undefined;
+    }, 15_000, `Prompt row "${title}" did not appear in the Prompts view`);
+
+    return found!;
+}
+
+async function waitForVersionTreeItem(promptItem: CustomTreeItem, labelSubstring: string): Promise<CustomTreeItem> {
+    const driver = VSBrowser.instance.driver;
+    let found: CustomTreeItem | undefined;
+
+    await driver.wait(async () => {
+        // getChildren() expands the prompt row if needed.
+        const children = await promptItem.getChildren();
+        for (const child of children) {
+            const label = await (child as CustomTreeItem).getLabel();
+            if (label.includes(labelSubstring)) {
+                found = child as CustomTreeItem;
+                return true;
+            }
+        }
+        return false;
+    }, 15_000, `Version row containing "${labelSubstring}" did not appear`);
+
+    return found!;
+}
+
+async function dismissOnboardingOverlay(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    try {
+        const overlay = await driver.findElement(By.css('.onboarding-a-overlay.visible'));
+        if (await overlay.isDisplayed()) {
+            await driver.executeScript('arguments[0].remove()', overlay);
+        }
+    } catch {
+        // Overlay is not present in most test runs.
+    }
+}
+
+async function runCommandViaKeyboard(commandLabel: string): Promise<void> {
+    await new Workbench().executeCommand(commandLabel);
+}
+
+async function retryCommand(commandLabel: string, retries = 3): Promise<void> {
+    for (let i = 0; i < retries; i++) {
+        try {
+            await closeQuickInput();
+            await runCommandViaKeyboard(commandLabel);
+            return;
+        } catch {
+            await VSBrowser.instance.driver.sleep(1500);
+        }
+    }
+    await runCommandViaKeyboard(commandLabel);
+}
+
+async function closeQuickInput(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    await resetKeyboardState();
+    await driver.actions().sendKeys(Key.ESCAPE).perform();
+    await driver.sleep(200);
+}
+
+async function resetKeyboardState(): Promise<void> {
+    await VSBrowser.instance.driver.actions().sendKeys(Key.NULL).perform();
+}

--- a/src/test/unit/aiEngine.test.ts
+++ b/src/test/unit/aiEngine.test.ts
@@ -1,0 +1,130 @@
+import { AIEngine } from '../../ai/aiEngine';
+
+/**
+ * Regression coverage for PR #77: "fail fast on worker summarize error
+ * instead of waiting for the 90s timeout".
+ *
+ * Before the fix, a worker-side error never carried the specific
+ * `requestId`, so `handleWorkerMessage()` could only flip the global
+ * `status` flag — it had no way to reject the one pending promise that
+ * actually failed. The caller of `summarizeViaWorker()` was left waiting
+ * for its own 90-second `setTimeout` fallback.
+ *
+ * These tests drive `AIEngine`'s private worker-message handling directly
+ * (via `as any`) with synthetic messages, instead of spawning a real
+ * `worker_threads` Worker — that would be slow/flaky and isn't needed since
+ * the fix lives entirely in how `AIEngine` interprets messages it receives.
+ */
+describe('AIEngine worker error handling (PR #77 fail-fast fix)', () => {
+    let engine: AIEngine;
+    let postMessage: jest.Mock;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        engine = AIEngine.getInstance();
+        // Reset internal state between tests; AIEngine is a singleton.
+        postMessage = jest.fn();
+        (engine as any).worker = { postMessage };
+        (engine as any).pendingRequests = new Map();
+        (engine as any).status = 'ready';
+    });
+
+    afterEach(() => {
+        (engine as any).pendingRequests = new Map();
+        (engine as any).worker = null;
+        (engine as any).status = 'uninitialized';
+        jest.useRealTimers();
+    });
+
+    function startRequest(text = 'some text to summarize'): { promise: Promise<string>; requestId: number } {
+        // Track the call count before invoking rather than asserting a fixed
+        // total, since some tests start more than one concurrent request.
+        const callsBefore = postMessage.mock.calls.length;
+        const promise: Promise<string> = (engine as any).summarizeViaWorker(text, 50);
+        expect(postMessage).toHaveBeenCalledTimes(callsBefore + 1);
+        const requestId = postMessage.mock.calls[callsBefore][0].requestId;
+        expect(typeof requestId).toBe('number');
+        return { promise, requestId };
+    }
+
+    it('rejects the specific pending request immediately on a matching error message, without waiting for the 90s timeout', async () => {
+        const { promise, requestId } = startRequest();
+
+        let settled = false;
+        promise.then(() => { settled = true; });
+
+        // No time is advanced here at all — proving settlement does not
+        // depend on the 90s (or any) timeout firing.
+        (engine as any).handleWorkerMessage({ type: 'error', requestId, error: 'worker exploded' });
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(settled).toBe(true);
+        // The 90s timeout for this request must have been cleared, not left
+        // pending — otherwise it would double-resolve later.
+        expect(jest.getTimerCount()).toBe(0);
+        expect((engine as any).pendingRequests.has(requestId)).toBe(false);
+    });
+
+    it('does not affect other concurrently pending requests when one is rejected', async () => {
+        const { promise: promiseA, requestId: idA } = startRequest('text A');
+        const { promise: promiseB, requestId: idB } = startRequest('text B');
+
+        expect(idA).not.toBe(idB);
+
+        let settledA = false;
+        let settledB = false;
+        promiseA.then(() => { settledA = true; });
+        promiseB.then(() => { settledB = true; });
+
+        (engine as any).handleWorkerMessage({ type: 'error', requestId: idA, error: 'boom' });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(settledA).toBe(true);
+        expect(settledB).toBe(false);
+        expect((engine as any).pendingRequests.has(idA)).toBe(false);
+        expect((engine as any).pendingRequests.has(idB)).toBe(true);
+        // Request B's own 90s timeout is still armed as its fallback safety net.
+        expect(jest.getTimerCount()).toBe(1);
+
+        // Clean up B so it doesn't leak a real pending timer into other tests.
+        (engine as any).handleWorkerMessage({ type: 'result', requestId: idB, title: 'B done' });
+        await expect(promiseB).resolves.toBe('B done');
+    });
+
+    it('still resolves the correct pending request normally on a genuine result message (no regression)', async () => {
+        const { promise, requestId } = startRequest();
+
+        (engine as any).handleWorkerMessage({ type: 'result', requestId, title: 'Generated Title' });
+
+        await expect(promise).resolves.toBe('Generated Title');
+        expect((engine as any).pendingRequests.has(requestId)).toBe(false);
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('falls back to the pre-fix behavior (global status flip, no fast rejection) when a message carries no requestId', async () => {
+        // This reproduces exactly what the OLD aiWorker.ts sent on error
+        // (no requestId at all) and demonstrates why that was a bug: the
+        // pending request is left untouched, so the caller can only be
+        // rescued by its own 90s timeout.
+        const { promise, requestId } = startRequest();
+
+        let settled = false;
+        promise.then(() => { settled = true; });
+
+        (engine as any).handleWorkerMessage({ type: 'error', error: 'boom, no requestId' });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(settled).toBe(false);
+        expect((engine as any).pendingRequests.has(requestId)).toBe(true);
+        expect((engine as any).status).toBe('error');
+
+        // It only settles once the 90s fallback timer actually fires.
+        jest.advanceTimersByTime(90000);
+        await Promise.resolve();
+        expect(settled).toBe(true);
+    });
+});

--- a/src/test/unit/clipboardManager.test.ts
+++ b/src/test/unit/clipboardManager.test.ts
@@ -165,6 +165,70 @@ describe('ClipboardManager.loadHistory', () => {
     });
 });
 
+describe('ClipboardManager fs error logging (PR #74 regression)', () => {
+    let tmpDir: string;
+    const fakePath = 'C:\\Users\\fakeuser\\.quickprompt\\clipboard-history.json';
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(realOs.tmpdir(), 'cm-fserr-test-'));
+        homedirMock.mockReturnValue(tmpDir);
+        readText.mockReset().mockResolvedValue('');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        jest.clearAllMocks();
+    });
+
+    it('does not leak the absolute storage path in logs when loadHistory fails to read the file', async () => {
+        // File must exist so loadHistory takes the fs.promises.readFile() branch.
+        const storageDir = path.join(tmpDir, '.quickprompt');
+        fs.mkdirSync(storageDir, { recursive: true });
+        fs.writeFileSync(path.join(storageDir, 'clipboard-history.json'), '[]', 'utf-8');
+
+        const fsError = Object.assign(
+            new Error(`ENOENT: no such file or directory, open '${fakePath}'`),
+            { code: 'ENOENT' }
+        );
+        jest.spyOn(fs.promises, 'readFile').mockRejectedValueOnce(fsError);
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const manager = new ClipboardManager(makeContext());
+        await flushMicrotasks();
+
+        const loggedMessages = errorSpy.mock.calls.map(call => call.join(' '));
+        expect(loggedMessages.some(msg => msg.includes('ENOENT'))).toBe(true);
+        expect(loggedMessages.some(msg => msg.includes('fakeuser'))).toBe(false);
+        expect(loggedMessages.some(msg => msg.includes(fakePath))).toBe(false);
+
+        manager.dispose();
+    });
+
+    it('does not leak the absolute storage path in logs when saveHistory fails to write the file', async () => {
+        const fsError = Object.assign(
+            new Error(`EACCES: permission denied, open '${fakePath}'`),
+            { code: 'EACCES' }
+        );
+        jest.spyOn(fs.promises, 'writeFile').mockRejectedValueOnce(fsError);
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const manager = new ClipboardManager(makeContext());
+        await flushMicrotasks();
+
+        readText.mockResolvedValue('Some long enough content to store');
+        await manager.checkClipboard('external');
+        await flushMicrotasks();
+
+        const loggedMessages = errorSpy.mock.calls.map(call => call.join(' '));
+        expect(loggedMessages.some(msg => msg.includes('EACCES'))).toBe(true);
+        expect(loggedMessages.some(msg => msg.includes('fakeuser'))).toBe(false);
+        expect(loggedMessages.some(msg => msg.includes(fakePath))).toBe(false);
+
+        manager.dispose();
+    });
+});
+
 describe('ClipboardManager.dispose', () => {
     let tmpDir: string;
 

--- a/src/test/unit/i18n.test.ts
+++ b/src/test/unit/i18n.test.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { I18n } from '../../i18n';
+
+/**
+ * Regression tests for PR #70: "avoid logging raw error object on i18n
+ * language file load failure" (src/i18n.ts, loadLanguageFile).
+ *
+ * These tests exercise the failure path of I18n.loadLanguageFile by pointing
+ * ExtensionContext.extensionUri at a temp directory that only contains an
+ * `en.json` locale file (no file for the "unsupported" locale requested).
+ * The mocked vscode.workspace.fs.readFile (src/test/__mocks__/vscode.ts)
+ * delegates to the real Node fs module, so requesting a missing locale file
+ * naturally rejects with an ENOENT-derived error, exactly like the failure
+ * this PR addressed.
+ */
+describe('I18n', () => {
+    let tmpDir: string;
+    let context: vscode.ExtensionContext;
+    let consoleLogSpy: jest.SpyInstance;
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-i18n-'));
+        fs.mkdirSync(path.join(tmpDir, 'i18n'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'i18n', 'en.json'),
+            JSON.stringify({ 'message.greeting': 'Hello {0}' })
+        );
+
+        context = { extensionUri: vscode.Uri.file(tmpDir) } as vscode.ExtensionContext;
+
+        // Reset the module-level singleton state between tests (private
+        // statics, accessed via `as any` since there is no public reset API).
+        (I18n as unknown as { isInitialized: boolean }).isInitialized = false;
+        (I18n as unknown as { messages: Record<string, string> }).messages = {};
+
+        consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        consoleLogSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+        (vscode.env as { language: string }).language = 'en';
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('does not throw when the requested locale file is missing', async () => {
+        (vscode.env as { language: string }).language = 'xx-unsupported';
+
+        await expect(I18n.initialize(context)).resolves.toBeUndefined();
+    });
+
+    it('falls back to English when the requested locale file fails to load', async () => {
+        (vscode.env as { language: string }).language = 'xx-unsupported';
+
+        await I18n.initialize(context);
+
+        expect(I18n.isReady()).toBe(true);
+        expect(I18n.getMessage('message.greeting', 'World')).toBe('Hello World');
+    });
+
+    it('does not log the raw error object/stack for a load failure, only the locale', async () => {
+        (vscode.env as { language: string }).language = 'xx-unsupported';
+
+        await I18n.initialize(context);
+
+        const failureCalls = consoleLogSpy.mock.calls.filter(call =>
+            typeof call[0] === 'string' && call[0].includes('Failed to load xx-unsupported.json')
+        );
+
+        expect(failureCalls.length).toBeGreaterThan(0);
+
+        for (const call of failureCalls) {
+            // The fix logs only the message string, no second "error" argument.
+            expect(call).toHaveLength(1);
+
+            // No argument in the call should be an Error instance or otherwise
+            // carry a stack trace / raw error payload.
+            for (const arg of call) {
+                expect(arg instanceof Error).toBe(false);
+                if (typeof arg === 'string') {
+                    expect(arg).not.toMatch(/\bat .*\(.*:\d+:\d+\)/); // stack trace frame
+                    expect(arg.toLowerCase()).not.toContain('enoent');
+                }
+            }
+        }
+
+        // Also confirm console.error was never used to dump the raw error for
+        // this path (initialize's own top-level catch is a separate concern).
+        for (const call of consoleErrorSpy.mock.calls) {
+            for (const arg of call) {
+                expect(arg instanceof Error).toBe(false);
+            }
+        }
+    });
+});

--- a/src/test/unit/privacyManager.test.ts
+++ b/src/test/unit/privacyManager.test.ts
@@ -40,6 +40,34 @@ describe('PrivacyManager', () => {
 
             expect(manager.unmaskText(maskedText)).toBe(original);
         });
+
+        // Regression for #63: a shorter custom-dictionary label that is a
+        // literal substring of a longer one must not be restored first, or
+        // it corrupts the still-unprocessed longer occurrence (here,
+        // "[SECRET]" is a true substring of "[SECRET]-BACKUP" — unlike the
+        // issue's original "[SECRET]"/"[SECRET-CODE]" example, which isn't
+        // actually a substring pair since "]" never lines up). Covers both
+        // dictionary-insertion orders since the bug depended on Map
+        // iteration order.
+        it('restores both values correctly when one label is a substring of another (shorter label added first)', () => {
+            manager.addDictionaryEntry({ pattern: 'sk_live_111', isRegex: false, label: '[SECRET]', enabled: true });
+            manager.addDictionaryEntry({ pattern: 'sk_live_222', isRegex: false, label: '[SECRET]-BACKUP', enabled: true });
+
+            const original = 'key sk_live_111 and code sk_live_222 must both roundtrip.';
+            const { maskedText } = manager.maskText(original);
+
+            expect(manager.unmaskText(maskedText)).toBe(original);
+        });
+
+        it('restores both values correctly when one label is a substring of another (longer label added first)', () => {
+            manager.addDictionaryEntry({ pattern: 'sk_live_222', isRegex: false, label: '[SECRET]-BACKUP', enabled: true });
+            manager.addDictionaryEntry({ pattern: 'sk_live_111', isRegex: false, label: '[SECRET]', enabled: true });
+
+            const original = 'key sk_live_111 and code sk_live_222 must both roundtrip.';
+            const { maskedText } = manager.maskText(original);
+
+            expect(manager.unmaskText(maskedText)).toBe(original);
+        });
     });
 
     // ── dictionary file shape guard ──────────────────────────────────────────

--- a/src/test/unit/promptHoverProvider.test.ts
+++ b/src/test/unit/promptHoverProvider.test.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { PromptHoverProvider } from '../../promptHoverProvider';
+import { Prompt } from '../../core/types';
+
+function makePrompt(overrides: Partial<Prompt> = {}): Prompt {
+    return {
+        id: 'testid',
+        title: 'My Prompt',
+        content: 'Some prompt content',
+        use_count: 0,
+        last_used: new Date().toISOString(),
+        created_at: new Date().toISOString(),
+        ...overrides,
+    };
+}
+
+describe('PromptHoverProvider', () => {
+    it('produces a hover MarkdownString with isTrusted falsy (regression: PR #68 command-link trust)', () => {
+        const provider = new PromptHoverProvider();
+        provider.updatePrompts([makePrompt()]);
+
+        const document = {
+            uri: vscode.Uri.parse('quickprompt:/testid.md'),
+        } as unknown as vscode.TextDocument;
+
+        const hover = provider.provideHover(
+            document,
+            {} as vscode.Position,
+            {} as vscode.CancellationToken
+        ) as vscode.Hover;
+
+        expect(hover).toBeTruthy();
+        const md = hover.contents as unknown as vscode.MarkdownString;
+        expect(md.isTrusted).toBeFalsy();
+        expect(md.isTrusted).not.toBe(true);
+    });
+
+    it('never sets isTrusted to true even for a title crafted to look like a command link', () => {
+        const provider = new PromptHoverProvider();
+        provider.updatePrompts([
+            makePrompt({ title: '[Click me](command:workbench.action.terminal.new)' }),
+        ]);
+
+        const document = {
+            uri: vscode.Uri.parse('quickprompt:/testid.md'),
+        } as unknown as vscode.TextDocument;
+
+        const hover = provider.provideHover(
+            document,
+            {} as vscode.Position,
+            {} as vscode.CancellationToken
+        ) as vscode.Hover;
+
+        const md = hover.contents as unknown as vscode.MarkdownString;
+        expect(md.isTrusted).toBeFalsy();
+    });
+});

--- a/src/test/unit/promptProviderFsErrorLogging.test.ts
+++ b/src/test/unit/promptProviderFsErrorLogging.test.ts
@@ -1,0 +1,85 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { PromptProvider } from '../../promptProvider';
+import { VersionHistoryService } from '../../services/VersionHistoryService';
+
+// Regression test for PR #67: PromptProvider catch blocks used to log the raw
+// fs error object, whose message embeds the full absolute workspace path
+// (e.g. "EISDIR: illegal operation on a directory, open 'C:\Users\...\prompts.json'").
+// The fix routes every such catch block through formatFsErrorForLog(), which
+// keeps only the error code/name and drops the path.
+describe('PromptProvider fs error logging (PR #67)', () => {
+    let tmpDir: string;
+    let promptsJsonPath: string;
+    let consoleErrorSpy: jest.SpyInstance;
+
+    function makeContext(): vscode.ExtensionContext {
+        const context = new (vscode as any).ExtensionContext();
+        const state = new Map<string, unknown>();
+        context.workspaceState = {
+            get: jest.fn((key: string, defaultValue?: unknown) => state.has(key) ? state.get(key) : defaultValue),
+            update: jest.fn((key: string, value: unknown) => {
+                state.set(key, value);
+                return Promise.resolve();
+            }),
+            keys: jest.fn(() => Array.from(state.keys()))
+        };
+        return context;
+    }
+
+    function loggedText(): string {
+        return consoleErrorSpy.mock.calls
+            .flat()
+            .map(arg => (arg instanceof Error ? `${arg.name}: ${arg.message}` : String(arg)))
+            .join('\n');
+    }
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qp-provider-fserr-'));
+        fs.mkdirSync(path.join(tmpDir, '.vscode'), { recursive: true });
+        promptsJsonPath = path.join(tmpDir, '.vscode', 'prompts.json');
+        // Start with a valid, loadable prompts.json so the initial refresh()
+        // succeeds and the workspace is NOT marked as failed-to-load.
+        fs.writeFileSync(promptsJsonPath, '[]', 'utf8');
+
+        (vscode.workspace as any).workspaceFolders = [
+            { name: 'SecretProject', uri: vscode.Uri.file(tmpDir) }
+        ];
+        (vscode.window as any).activeTextEditor = undefined;
+        jest.clearAllMocks();
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        (vscode.workspace as any).workspaceFolders = undefined;
+        (vscode.window as any).activeTextEditor = undefined;
+    });
+
+    it('logs only the fs error code, not the full workspace path, when saving prompts fails', async () => {
+        const context = makeContext();
+        const provider = new PromptProvider(context, new VersionHistoryService(context));
+
+        // Load succeeds normally while prompts.json is still a real file.
+        await provider.refresh();
+
+        // Simulate the prompts.json path becoming unwritable (e.g. replaced by a
+        // directory) after a successful load, so the next save hits the fs error
+        // catch block in savePrompts() rather than the "failed to load" guard.
+        fs.rmSync(promptsJsonPath, { force: true });
+        fs.mkdirSync(promptsJsonPath);
+
+        await expect(provider.addPromptWithOption('Prompt A', 'content A', true)).rejects.toThrow();
+
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        const text = loggedText();
+
+        // The absolute workspace path must never appear in the log output.
+        expect(text).not.toContain(tmpDir);
+        // The useful error code should still be present.
+        expect(text).toMatch(/EISDIR/);
+    });
+});

--- a/src/test/unit/versionCommands.test.ts
+++ b/src/test/unit/versionCommands.test.ts
@@ -1,0 +1,104 @@
+import * as vscode from 'vscode';
+import { handleShowVersionDiff } from '../../commands/versionCommands';
+import { VersionItem } from '../../treeItems/VersionItem';
+import { VersionHistoryService } from '../../services/VersionHistoryService';
+import { VersionHistory, PromptVersion } from '../../types/versionHistory';
+
+// PR #71 regression coverage: VS Code only allows a single
+// TextDocumentContentProvider per URI scheme ('prompt-history' here). The
+// pre-fix code relied solely on a 60s setTimeout to dispose the previous
+// registration, so opening a second version diff within that window threw.
+// The fix disposes the previous registration synchronously before
+// registering the new one, and guards the delayed cleanup so it never
+// double-disposes a registration that was already replaced.
+describe('handleShowVersionDiff (PR #71 dispose-before-register regression)', () => {
+    function makeVersion(versionId: string, content: string): PromptVersion {
+        return {
+            versionId,
+            content,
+            timestamp: Date.now(),
+            changeType: 'edit',
+        };
+    }
+
+    function makeItem(promptId: string, version: PromptVersion): VersionItem {
+        return { promptId, version, isCurrent: false } as unknown as VersionItem;
+    }
+
+    function makeService(history: VersionHistory): VersionHistoryService {
+        return {
+            loadHistory: jest.fn().mockResolvedValue(history),
+        } as unknown as VersionHistoryService;
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('disposes the previous registration before registering the next one, and never throws on the second call', async () => {
+        const versionA = makeVersion('v1', 'content A');
+        const versionB = makeVersion('v2', 'content B');
+        const current = makeVersion('current', 'current content');
+        const history: VersionHistory = {
+            promptId: 'p1',
+            versions: [versionA, versionB, current],
+            currentVersionId: 'current',
+        };
+        const service = makeService(history);
+
+        const registerSpy = jest.spyOn(vscode.workspace, 'registerTextDocumentContentProvider');
+
+        // First call registers a provider for the 'prompt-history' scheme.
+        await handleShowVersionDiff(makeItem('p1', versionA), service);
+        expect(registerSpy).toHaveBeenCalledTimes(1);
+        const firstRegistration = registerSpy.mock.results[0].value as vscode.Disposable;
+        const firstDisposeSpy = jest.spyOn(firstRegistration, 'dispose');
+
+        // Second call must not throw even though only one 'prompt-history'
+        // provider may be registered at a time (mock enforces this like real VS Code).
+        await expect(
+            handleShowVersionDiff(makeItem('p1', versionB), service)
+        ).resolves.not.toThrow();
+
+        expect(registerSpy).toHaveBeenCalledTimes(2);
+        // The previous registration's dispose() must have been called before
+        // the second registerTextDocumentContentProvider call succeeded.
+        expect(firstDisposeSpy).toHaveBeenCalledTimes(1);
+
+        const secondRegistration = registerSpy.mock.results[1].value as vscode.Disposable;
+        const secondDisposeSpy = jest.spyOn(secondRegistration, 'dispose');
+
+        // Fast-forward past the delayed cleanup (60s) for both calls. The
+        // first registration's guarded timeout must not double-dispose it,
+        // and the second registration's timeout should dispose it exactly once.
+        jest.advanceTimersByTime(60000);
+
+        expect(firstDisposeSpy).toHaveBeenCalledTimes(1);
+        expect(secondDisposeSpy).toHaveBeenCalledTimes(1);
+
+        registerSpy.mockRestore();
+    });
+
+    it('does not error when no error message is shown for the second diff', async () => {
+        const versionA = makeVersion('v1', 'content A');
+        const versionB = makeVersion('v2', 'content B');
+        const current = makeVersion('current', 'current content');
+        const history: VersionHistory = {
+            promptId: 'p1',
+            versions: [versionA, versionB, current],
+            currentVersionId: 'current',
+        };
+        const service = makeService(history);
+        const errorSpy = jest.spyOn(vscode.window, 'showErrorMessage');
+
+        await handleShowVersionDiff(makeItem('p1', versionA), service);
+        await handleShowVersionDiff(makeItem('p1', versionB), service);
+
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/test/unit/versionHistoryService.test.ts
+++ b/src/test/unit/versionHistoryService.test.ts
@@ -57,4 +57,39 @@ describe('VersionHistoryService', () => {
             expect(history).toEqual({ promptId: 'abc', versions: [], currentVersionId: '' });
         });
     });
+
+    describe('saveHistory error logging', () => {
+        it('does not leak the raw fs error (with absolute path) to the console, but still rethrows it', async () => {
+            const fakePath = 'C:\\Users\\faketestuser\\project\\.vscode\\.quickprompt\\history\\abc.history.json';
+            const fsError = Object.assign(
+                new Error(`EPERM: operation not permitted, open '${fakePath}'`),
+                { code: 'EPERM' }
+            );
+
+            const writeFileSpy = jest
+                .spyOn(vscode.workspace.fs, 'writeFile')
+                .mockRejectedValueOnce(fsError);
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+            try {
+                await expect(
+                    service.saveHistory({ promptId: 'abc', versions: [], currentVersionId: '' })
+                ).rejects.toBe(fsError);
+
+                expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+                const loggedOutput = consoleErrorSpy.mock.calls
+                    .map(call => call.map(arg => (arg instanceof Error ? arg.stack ?? arg.message : String(arg))).join(' '))
+                    .join('\n');
+
+                // The absolute path and the fake username it contains must never reach the log.
+                expect(loggedOutput).not.toContain(fakePath);
+                expect(loggedOutput).not.toContain('faketestuser');
+                // But the error code should still be present so the failure is identifiable.
+                expect(loggedOutput).toContain('EPERM');
+            } finally {
+                writeFileSpy.mockRestore();
+                consoleErrorSpy.mockRestore();
+            }
+        });
+    });
 });

--- a/src/test/unit/versionItem.test.ts
+++ b/src/test/unit/versionItem.test.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+import { VersionItem } from '../../treeItems/VersionItem';
+import { PromptVersion } from '../../types/versionHistory';
+
+function makeVersion(overrides: Partial<PromptVersion> = {}): PromptVersion {
+    return {
+        versionId: 'v1',
+        content: 'Some version content',
+        timestamp: Date.now(),
+        changeType: 'edit',
+        ...overrides,
+    };
+}
+
+describe('VersionItem', () => {
+    it('produces a tooltip MarkdownString with isTrusted falsy (regression: PR #68 command-link trust)', () => {
+        const item = new VersionItem('promptA', makeVersion(), false);
+
+        const tooltip = item.tooltip as unknown as vscode.MarkdownString;
+        expect(tooltip).toBeTruthy();
+        expect(tooltip.isTrusted).toBeFalsy();
+        expect(tooltip.isTrusted).not.toBe(true);
+    });
+
+    it('never sets isTrusted to true even for a milestone label crafted to look like a command link', () => {
+        const item = new VersionItem(
+            'promptA',
+            makeVersion({
+                milestone: {
+                    label: '[Click me](command:workbench.action.terminal.new)',
+                    createdAt: Date.now(),
+                },
+            }),
+            false
+        );
+
+        const tooltip = item.tooltip as unknown as vscode.MarkdownString;
+        expect(tooltip.isTrusted).toBeFalsy();
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes #63: `unmaskText()` restores longer masked values before shorter ones that could be their literal prefix, preventing corruption when custom dictionary labels overlap (e.g. `[SECRET]` vs `[SECRET]-BACKUP`). Note: the issue's own example (`[SECRET]`/`[SECRET-CODE]`) isn't actually a substring pair — verified and used a real repro instead. **Caveat: `PrivacyManager`'s dictionary feature is not wired into the VS Code extension's UI at all — it's only reachable from the standalone `qp.bundle.js` CLI (shipped as the `quickprompt` Claude Code skill). The fix is correct but doesn't affect any VS Code UI user today.**
- Fills unit-test-coverage gaps identified while reviewing the just-merged routine batch (#66-#80): #67, #68 (security), #70, #71, #73 (+ new isolated jest infra for `mcp-server/`), #74, #75, #77, #80. #78 was investigated and found impractical to unit test without a production refactor — documented instead of forcing a low-value test.
- Adds real E2E/UI coverage (`src/test/ui/`) for: #79 (MCP config webview HTML escaping — security), #66 (malformed-config resilience), #71 (rapid version-diff switching), and a narrower smoke test for #77 (AI doesn't block the UI). #63/#69/#78 were investigated and found not meaningfully E2E-testable — documented why. **#68's E2E attempt was removed after extensive troubleshooting**: across every hover-trigger mechanism tried (mouse dwell, command-based, mouse + retries), the tooltip never once rendered within the wait window in this environment — consistently, not intermittently — so it measured nothing. `isTrusted === false` remains fully covered by the deterministic unit test.
- Along the way, fixed two latent bugs the new tests surfaced (unrelated to any PR in this batch): `formatFsErrorForLog()` in `promptProvider.ts` gated on `instanceof Error`, which fails for real fs errors crossing Jest's per-file VM context boundary; and a pre-existing bug in `quickPrompt.ui.test.ts` where two tests left scratch "Untitled" buffers open and dirty, which could hard-hang a full `test:ui` run behind a native OS "Save As" dialog that WebDriver can't interact with.

## Test plan
- [x] `npm test` (root): 20/20 suites, 158/158 tests passing
- [x] `cd mcp-server && npm test`: 2/2 suites, 8/8 tests passing (new isolated infra)
- [x] Every new unit regression test verified fail-before/pass-after against the relevant fix
- [x] `npm run test:ui`: run live by the repo owner across several iterations; the scratch-buffer dialog hang is fixed, PR #79/#71/#66/#77 all pass reliably, PR #68's E2E was removed per above