### PR TITLE
chore: release v0.8.0 (stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "Quick Prompt" extension will be documented in this file.
 
+## [0.8.0] - Stable Release: Maintenance - 2026-08-19
+
+Promotes the [0.7.0] pre-release content to stable unchanged — no new code in this release.
+
+- **test:** anchor jest `.claude` ignore pattern to `rootDir` (#62)
+- **chore(deps):** bump the `npm_and_yarn` dependency group across 1 directory with 6 updates (#61)
+
 ## [0.7.0] - Maintenance (pre-release) - 2026-07-26
 
 ### 🔧 Maintenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quick-prompt",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quick-prompt",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "license": "MIT",
             "dependencies": {
                 "@huggingface/transformers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "quick-prompt",
     "displayName": "Quick Prompt - Capture Ideas & Queue Tasks While AI Works",
     "description": "%extension.description%",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "publisher": "winterdrive",
     "icon": "docs/assets/quickprompt_icon_128.png",
     "license": "MIT",


### PR DESCRIPTION
## Summary

- Promotes the [0.7.0] pre-release content to stable as `0.8.0`, unchanged — no new code in this release.
- Follows this project's channel-promotion release convention (see `0.5.8` → `0.6.0` for precedent): a pre-release that has run for a few weeks without issue gets a pure version bump to stable.
- Even minor (`8`) → stable channel per `publish.yml`'s convention.

## What's included

Same content as `0.7.0`:
- test: anchor jest `.claude` ignore pattern to `rootDir` (#62)
- chore(deps): bump the `npm_and_yarn` dependency group across 1 directory with 6 updates (#61)

## Test plan

- [x] `package.json`/`package-lock.json` version bumped to `0.8.0`, no other diffs
- [x] `CHANGELOG.md` updated with the promotion entry
- [ ] CI passes