### PR TITLE
[Routine - QP] Fix raw error leak in ClipboardManager constructor load path

### DIFF
--- a/src/ClipboardManager.ts
+++ b/src/ClipboardManager.ts
@@ -66,7 +66,7 @@ export class ClipboardManager {
                 this.historyLoaded = true;
                 this._onHistoryChanged.fire();
             })
-            .catch(err => console.error('Failed to load clipboard history:', err));
+            .catch(err => console.error(`Failed to load clipboard history: ${formatFsErrorForLog(err)}`));
         this.setupListeners();
     }
 


### PR DESCRIPTION
## 1. Pre-flight Check

- `git status --short` was clean before starting.
- Open PRs at task start: **none** (`gh pr list --state open` returned `[]`).
- Active remote `routine/qp-fix-*` branches exist (e.g. `routine/qp-fix-clipboard-history-path-leak-260806`, `routine/qp-fix-clipboard-treeview-disposal-260816`, `routine/qp-fix-mcp-clipboard-error-leak-260807`, etc.), but all of their fixes are already present in `master`'s commit history (squash-merged) — none has an open PR, and `git log --oneline -- src/ClipboardManager.ts` confirms none touched the specific line changed here (constructor-level `.catch` at the old line 69).
- No overlap: this PR touches only `src/ClipboardManager.ts` line 69, a spot none of the prior related commits (`bec3379`, `2c36e2d`, etc.) modified.

## 2. Changes

`ClipboardManager`'s constructor calls `this.loadHistory().catch(err => console.error('Failed to load clipboard history:', err))`. Logging the raw `err` can leak the full `clipboard-history.json` path (including the user's home directory) into the log output. The file already defines and uses a `formatFsErrorForLog()` helper for exactly this purpose inside `loadHistory()`/`saveHistory()` (added in a prior routine fix), but this constructor call site was missed. This PR applies the same helper here for consistency:

```diff
- .catch(err => console.error('Failed to load clipboard history:', err));
+ .catch(err => console.error(`Failed to load clipboard history: ${formatFsErrorForLog(err)}`));
```

- Does not modify any MCP tool schema, name, or parameter in `mcp-server/src/tools/`.
- Does not add, remove, or update any dependency.
- Does not modify `package.json`, `package-lock.json`, or `CHANGELOG.md`.

## 3. Safety Verification

Commands run locally, all passed:

```bash
npx tsc -p ./
npm run test
```

- `npx tsc -p ./` — no errors.
- `npm run test` (Jest) — 20 suites / 158 tests passed, 0 failed.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.