### PR TITLE
[Routine - QP] Fix raw error message leak in version command notifications

### DIFF
--- a/src/commands/versionCommands.ts
+++ b/src/commands/versionCommands.ts
@@ -11,6 +11,19 @@ import { executeWithConfirmation } from '../utils';
 let activeVersionDiffRegistration: vscode.Disposable | undefined;
 
 /**
+ * Format an error for display in a VS Code notification, keeping only the
+ * error code (e.g. ENOENT/EACCES) rather than the raw error.message, which
+ * for fs errors typically embeds the full local file path.
+ */
+function formatErrorForDisplay(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'code' in error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code) return code;
+    }
+    return 'unknown error';
+}
+
+/**
  * Show diff between a historical version and the current version
  */
 export async function handleShowVersionDiff(
@@ -122,14 +135,22 @@ export async function handleApplyVersion(
 
         vscode.window.showInformationMessage(I18n.getMessage('message.versionApplied'));
 
-    } catch (error: any) {
+    } catch (error) {
         console.error('Failed to apply version:', error);
 
+        const errorCode = typeof error === 'object' && error !== null
+            ? (error as NodeJS.ErrnoException).code
+            : undefined;
+        const errorMessage = typeof error === 'object' && error !== null
+            && typeof (error as { message?: unknown }).message === 'string'
+            ? (error as { message: string }).message
+            : '';
+
         // Provide more friendly error message
-        let userMessage = I18n.getMessage('message.applyVersionFailed', error.message);
-        if (error.code === 'FileNotFound') {
+        let userMessage = I18n.getMessage('message.applyVersionFailed', formatErrorForDisplay(error));
+        if (errorCode === 'FileNotFound') {
             userMessage = I18n.getMessage('message.applyVersionFailedFileNotFound');
-        } else if (error.message.includes('permission')) {
+        } else if (errorMessage.includes('permission')) {
             userMessage = I18n.getMessage('message.applyVersionFailedPermission');
         }
 
@@ -172,9 +193,9 @@ export async function handleTagMilestone(
         await promptProvider.refresh();
 
         vscode.window.showInformationMessage(I18n.getMessage('message.milestoneTagged', label));
-    } catch (error: any) {
+    } catch (error) {
         console.error('Failed to tag milestone:', error);
-        vscode.window.showErrorMessage(I18n.getMessage('message.tagMilestoneFailed', error.message));
+        vscode.window.showErrorMessage(I18n.getMessage('message.tagMilestoneFailed', formatErrorForDisplay(error)));
     }
 }
 
@@ -218,9 +239,9 @@ export async function handleRenameMilestone(
         await promptProvider.refresh();
 
         vscode.window.showInformationMessage(I18n.getMessage('message.milestoneRenamed', label));
-    } catch (error: any) {
+    } catch (error) {
         console.error('Failed to rename milestone:', error);
-        vscode.window.showErrorMessage(I18n.getMessage('message.renameMilestoneFailed', error.message));
+        vscode.window.showErrorMessage(I18n.getMessage('message.renameMilestoneFailed', formatErrorForDisplay(error)));
     }
 }
 
@@ -256,9 +277,9 @@ export async function handleRemoveMilestone(
         await promptProvider.refresh();
 
         vscode.window.showInformationMessage(I18n.getMessage('message.milestoneRemoved'));
-    } catch (error: any) {
+    } catch (error) {
         console.error('Failed to remove milestone:', error);
-        vscode.window.showErrorMessage(I18n.getMessage('message.removeMilestoneFailed', error.message));
+        vscode.window.showErrorMessage(I18n.getMessage('message.removeMilestoneFailed', formatErrorForDisplay(error)));
     }
 }
 
@@ -286,9 +307,9 @@ export async function handleDeleteVersion(
                 await promptProvider.refresh();
 
                 vscode.window.showInformationMessage(I18n.getMessage('message.versionDeleted'));
-            } catch (error: any) {
+            } catch (error) {
                 console.error('Failed to delete version:', error);
-                vscode.window.showErrorMessage(I18n.getMessage('message.deleteVersionFailed', error.message));
+                vscode.window.showErrorMessage(I18n.getMessage('message.deleteVersionFailed', formatErrorForDisplay(error)));
             }
         }
     );
@@ -307,8 +328,8 @@ export async function handleCopyVersionContent(
         await vscode.env.clipboard.writeText(outputText);
         const label = item.version.milestone?.label || new Date(item.version.timestamp).toLocaleString();
         vscode.window.showInformationMessage(I18n.getMessage('message.versionContentCopied', label));
-    } catch (error: any) {
+    } catch (error) {
         console.error('Failed to copy version content:', error);
-        vscode.window.showErrorMessage(I18n.getMessage('message.copyFailed', error.message));
+        vscode.window.showErrorMessage(I18n.getMessage('message.copyFailed', formatErrorForDisplay(error)));
     }
 }


### PR DESCRIPTION
## 1. Pre-flight Check

**Open PRs checked:**
- #85 `[Routine - QP] Fix raw error leak in ClipboardManager constructor load path` (branch `routine/qp-fix-clipboardmanager-ctor-error-leak-260819`) — touches only `src/ClipboardManager.ts`.

**Active routine branches on origin** (sampled by name, none currently have open PRs besides #85): a long series of prior `routine/qp-fix-*` branches covering path-leak/listener-leak/JSON-shape fixes across `ClipboardManager.ts`, `promptProvider.ts`, `VersionHistoryService.ts`, MCP tools, i18n, hover provider, masking engine, secret storage, workers, etc.

**Why this PR does not overlap:**
This PR only touches `src/commands/versionCommands.ts`, which is not modified by PR #85 or referenced by any of the sampled branch names above. The specific bug (raw `error.message` shown directly in `vscode.window.showErrorMessage()` notifications) is also a different code path from the prior fixes, which addressed `console.error` logging (via a `formatFsErrorForLog` helper in `promptProvider.ts` / `ClipboardManager.ts` / `VersionHistoryService.ts`) rather than user-facing notification text.

## 2. Changes

`src/commands/versionCommands.ts`:
- Added a local `formatErrorForDisplay(error: unknown)` helper that returns only the error's `.code` (e.g. `ENOENT`/`EACCES`) or a generic fallback, mirroring the existing `formatFsErrorForLog` pattern already used elsewhere for safe logging.
- `handleApplyVersion`, `handleTagMilestone`, `handleRenameMilestone`, `handleRemoveMilestone`, `handleDeleteVersion`, `handleCopyVersionContent` now pass `formatErrorForDisplay(error)` to their `I18n.getMessage(...)` calls instead of the raw `error.message`, which for filesystem errors typically embeds the full local file path and was being shown directly in a visible VS Code toast notification.
- `handleApplyVersion`'s catch block previously typed the caught value as `any` and unconditionally called `error.code` / `error.message.includes(...)`; this would throw if a non-`Error` value were thrown. Changed the catch parameter to `unknown` and added type guards before reading `.code`/`.message`.

This PR does **not** modify any MCP tool schema/name/parameter in `mcp-server/src/tools/`, and does not add/remove/update any dependencies.

## 3. Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./
npm run test:coverage
```

- `tsc`: no errors.
- `test:coverage`: 20 test suites passed, 158 tests passed, coverage thresholds met (no `lint` or `format:check` script exists in `package.json`, so those were skipped).

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.