### PR TITLE
[Routine - QP] Fix disposed watcher leak in PromptProvider subscriptions

### DIFF
--- a/src/promptProvider.ts
+++ b/src/promptProvider.ts
@@ -84,12 +84,21 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
                 await this.refresh();
             })
         );
+
+        // 註冊一次性的 watcher 清理器：setupWorkspaces() 會在每次工作區變化時
+        // 重建 watchers，若逐個 push 進 context.subscriptions 會讓已 dispose
+        // 的舊 watcher 參照永久留在陣列中而不斷累積。
+        context.subscriptions.push({ dispose: () => this.disposeWatchers() });
+    }
+
+    private disposeWatchers(): void {
+        this.watchers.forEach(w => w.dispose());
+        this.watchers = [];
     }
 
     private setupWorkspaces() {
         // 清理舊的 watchers
-        this.watchers.forEach(w => w.dispose());
-        this.watchers = [];
+        this.disposeWatchers();
         this.workspaceConfigs = [];
 
         const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -125,7 +134,6 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
                     }
                 });
                 this.watchers.push(watcher);
-                this.context.subscriptions.push(watcher);
             });
         } else {
             // Fallback: Global storage or extension directory
@@ -146,7 +154,6 @@ export class PromptProvider implements vscode.TreeDataProvider<PromptTreeItem> {
                 }
             });
             this.watchers.push(watcher);
-            this.context.subscriptions.push(watcher);
         }
 
         this.activeWorkspaceScopeKeys = this.normalizeWorkspaceScope(

--- a/src/test/unit/promptProviderMultiroot.test.ts
+++ b/src/test/unit/promptProviderMultiroot.test.ts
@@ -225,6 +225,24 @@ describe('PromptProvider multi-root routing', () => {
         expect(provider.getQuickCreateWorkspaceKey()).toBe(projectBKey);
     });
 
+    it('does not accumulate disposed file watchers in context.subscriptions on repeated workspace changes', async () => {
+        writePrompts(tmpDir1, []);
+        writePrompts(tmpDir2, []);
+
+        const context = makeContext();
+        const provider = new PromptProvider(context, new VersionHistoryService(context));
+        await provider.refresh();
+
+        const subscriptionCountAfterInit = context.subscriptions.length;
+
+        // Simulate several workspace-folder-change events (each rebuilds watchers).
+        (provider as unknown as { setupWorkspaces: () => void }).setupWorkspaces();
+        (provider as unknown as { setupWorkspaces: () => void }).setupWorkspaces();
+        (provider as unknown as { setupWorkspaces: () => void }).setupWorkspaces();
+
+        expect(context.subscriptions.length).toBe(subscriptionCountAfterInit);
+    });
+
     it('remembers the last create workspace when scope shows all workspaces', async () => {
         writePrompts(tmpDir1, []);
         writePrompts(tmpDir2, []);


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs checked before starting:
- #86 `routine/qp-fix-versioncommands-error-message-leak-260820` — touches `src/commands/versionCommands.ts`
- #85 `routine/qp-fix-clipboardmanager-ctor-error-leak-260819` — touches `src/ClipboardManager.ts`

Also reviewed the full `routine/qp-fix-*` branch history (40+ prior branches) to avoid re-treading already-fixed ground (raw error/path leaks, listener disposal, malformed-JSON guards).

This PR only touches `src/promptProvider.ts` and its test file `src/test/unit/promptProviderMultiroot.test.ts`, which do not overlap with either open PR or any prior routine branch name.

## 2. Changes

`PromptProvider.setupWorkspaces()` rebuilds its `prompts.json` file watchers every time workspace folders change, disposing the previous watchers directly via a `this.watchers` array. However, each individual watcher was *also* pushed onto `context.subscriptions` at creation time. Since disposed watchers are never removed from `context.subscriptions`, every workspace-folder-change event left stale, already-disposed watcher references permanently in that array — an unbounded accumulation over a long-running session.

Fix: register a single `{ dispose: () => this.disposeWatchers() }` entry in `context.subscriptions` once (in the constructor), instead of pushing each per-workspace watcher individually. `disposeWatchers()` is a small extracted helper reused by both the constructor's cleanup registration and `setupWorkspaces()`'s existing cleanup-before-rebuild step.

Added a regression test (`does not accumulate disposed file watchers in context.subscriptions on repeated workspace changes`) that simulates repeated workspace-folder-change events and asserts `context.subscriptions.length` stays constant.

Confirms: no MCP tool schemas, `package.json`, or dependencies were touched.

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` — 20 suites / 159 tests passed
- `npm run test:coverage -- --testPathPattern="promptProvider"` — 2 suites / 11 tests passed (coverage thresholds are scoped to `core/PromptManager.ts`, `core/PathUtils.ts`, `core/VersionManager.ts` per `jest.config.js` and are unaffected by this change)

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG.md consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior, not a code validation failure.