### PR TITLE
[Routine - QP] Fix raw error object leak in VersionHistoryService parse-failure log

### DIFF
--- a/src/services/VersionHistoryService.ts
+++ b/src/services/VersionHistoryService.ts
@@ -95,7 +95,7 @@ export class VersionHistoryService {
             }
             if (error instanceof SyntaxError) {
                 // Corrupted JSON file — reset rather than crash the tree view/migration flow
-                console.error(`Failed to parse version history for ${promptId}, resetting to empty:`, error);
+                console.error(`Failed to parse version history for ${promptId}, resetting to empty: ${formatFsErrorForLog(error)}`);
                 const resetHistory: VersionHistory = {
                     promptId,
                     versions: [],


### PR DESCRIPTION
## Pre-flight Check

Open PRs at time of this run:
- #87 `routine/qp-fix-promptprovider-watcher-subscription-leak-260821` — touches `src/promptProvider.ts`, `src/test/unit/promptProviderMultiroot.test.ts`
- #86 `routine/qp-fix-versioncommands-error-message-leak-260820` — touches `src/commands/versionCommands.ts`
- #85 `routine/qp-fix-clipboardmanager-ctor-error-leak-260819` — touches `src/ClipboardManager.ts`

This PR only touches `src/services/VersionHistoryService.ts`, which none of the above PRs modify. No overlap.

## Changes

`VersionHistoryService.loadHistory()` has two error branches: an invalid-shape branch (safe, string-only log) and a `SyntaxError` branch for corrupted JSON files. The sibling `saveHistory()` method already routes its failure log through the file's own `formatFsErrorForLog()` helper (added in PR #80) to avoid printing a raw `Error` object — which can carry a full stack trace with absolute file paths — to the console. The `loadHistory()` parse-failure branch was missed in that earlier fix and still called `console.error(msg, error)` with the raw error object.

This PR routes that one remaining call through the same `formatFsErrorForLog()` helper already defined in the file, matching the existing pattern used elsewhere in this file and across the codebase (e.g. `ClipboardManager.ts`, `promptProvider.ts`).

Confirms: no MCP tool schema/name/parameter changes, no dependency changes, no `package.json`/`package-lock.json` edits, no `CHANGELOG.md` edits.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test:coverage` — 20 test suites passed, 158/158 tests passed (including `src/test/unit/versionHistoryService.test.ts`, whose console output confirms the log now prints only `SyntaxError` instead of the full error/stack)

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.