### PR TITLE
docs: fix MCP tool count (21->17) and add Edo Tensei companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It combines a **persistent snippet library** with **clipboard history tracking**
 The QuickPrompt skill includes built-in safety logic to ensure stable operation:
 
 1. **Layer 0: Connection Gate** — Automatic check via `list_prompts`. If disconnected, the agent HALTS and asks for fallback.
-2. **Layer 1: Standard MCP Tools** — Use 21 tools for CRUD, versioning, and privacy masking.
+2. **Layer 1: Standard MCP Tools** — Use 17 tools for CRUD, versioning, and clipboard history.
 3. **Layer 2: Safety Verification** — Internal sanity checks across different prompt contexts.
 4. **Layer 3: Fallback CLI** — A bundled `qp.bundle.js` script allows the agent to edit `prompts.json` directly if the server is offline.
 
@@ -52,7 +52,7 @@ One-click configuration for every major AI tool. Run: `Quick Prompt: Show MCP Co
 
 ### 🔌 AI Agent Power (New!)
 
-- **🔌 21 MCP Tools**: Complete prompt management suite for AI agents.
+- **🔌 17 MCP Tools**: Complete prompt management suite for AI agents.
 - **🛡️ Action Decision Tree**: Ensures agents only act when connected and safe.
 - **📦 CLI Fallback Bundle**: Built-in script fallback for offline scenarios.
 - **⚙️ Interactive Config Panel**: Easy setup for Cursor, Copilot, Cline, Claude, and more.
@@ -303,7 +303,7 @@ Open VSCode Settings and search for "Quick Prompt":
 
 ---
 
-## 🤝 Recommended Companion
+## 🤝 Recommended Companions
 
 ### 🗂️ VirtualTabs
 
@@ -315,6 +315,14 @@ Open VSCode Settings and search for "Quick Prompt":
 - **VirtualTabs**: organize which files belong to which task — across any directory
 
 Get VirtualTabs on [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=winterdrive.virtual-tabs) | [**Open VSX Registry**](https://open-vsx.org/extension/winterdrive/virtual-tabs)
+
+### 🔁 Edo Tensei
+
+**When the session itself needs to move, not just your thoughts.**
+
+Quick Prompt buffers what you're thinking *within* a session. [Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei) carries the session *across* IDEs when quota runs out or an agent crashes mid-task.
+
+Get Edo Tensei on [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) | [**Open VSX Registry**](https://open-vsx.org/extension/Pain-Labs/edo-tensei)
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -34,7 +34,7 @@
 QuickPrompt Skill には、安全で安定した動作を保証する組み込みロジックが含まれています：
 
 1. **Layer 0: 接続ゲート** — `list_prompts` による自動接続確認。MCP が切断された場合、エージェントは即座に HALT と判定し、フォールバック処理をユーザーに提示します。
-2. **Layer 1: 標準 MCP ツール** — プロンプトの CRUD 操作、バージョン管理、プライバシーマスキングを扱う 21 個のツール。
+2. **Layer 1: 標準 MCP ツール** — プロンプトの CRUD 操作、バージョン管理、クリップボード履歴を扱う 17 個のツール。
 3. **Layer 2: 安全検証** — 敏感な操作の実行前に内部的なサニティチェックを実施し、データ整合性を確保。
 4. **Layer 3: CLI フォールバック** — MCP サーバーが利用不可の場合、エージェントは内蔵の `qp.bundle.js` スクリプトに切り替えてデータベースに直接アクセス。
 
@@ -52,7 +52,7 @@ QuickPrompt Skill には、安全で安定した動作を保証する組み込�
 
 ### 🔌 AI エージェント パワーアップ (新機能!)
 
-- **🔌 21 個の MCP ツール**：AI エージェント用の完全なプロンプト管理スイート。
+- **🔌 17 個の MCP ツール**：AI エージェント用の完全なプロンプト管理スイート。
 - **🛡️ アクション判定ツリー**：エージェントは接続状態が安全で実行可能な場合にのみ動作。
 - **📦 CLI フォールバック バンドル**：オフライン時に利用できる内蔵スクリプト。
 - **⚙️ インタラクティブ設定パネル**：Cursor、Copilot、Cline、Claude など主要ツールの簡単セットアップ。
@@ -272,6 +272,14 @@ Quick Prompt v0.5.1 は拡張コマンドを `quickPrompt.*` namespace に統一
 - **VirtualTabs**：ディレクトリ横断して、どのファイルがどのタスクに属するかを整理
 
 [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=winterdrive.virtual-tabs) | [**Open VSX Registry**](https://open-vsx.org/extension/winterdrive/virtual-tabs) で取得
+
+### 🔁 Edo Tensei
+
+**移動が必要なのは思考だけでなく、セッションそのものであるとき。**
+
+Quick Prompt がバッファするのは、セッション *内* で考えていることです。[Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei) は、クォータが切れたり途中でエージェントがクラッシュしたりしたとき、セッションを IDE を *またいで* 運びます。
+
+[**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) | [**Open VSX Registry**](https://open-vsx.org/extension/Pain-Labs/edo-tensei) で Edo Tensei を取得
 
 ---
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -34,7 +34,7 @@
 QuickPrompt Skill에는 안정적인 운영을 보장하는 내장 안전 로직이 포함되어 있습니다:
 
 1. **Layer 0: 연결 게이트** — `list_prompts`를 통한 자동 연결 확인. MCP가 끊기면 에이전트는 즉시 HALT를 트리거하고 폴백 처리를 제시합니다.
-2. **Layer 1: 표준 MCP 도구** — 프롬프트의 CRUD 작업, 버전 관리, 개인정보 마스킹을 다루는 21개의 도구.
+2. **Layer 1: 표준 MCP 도구** — 프롬프트의 CRUD 작업, 버전 관리, 클립보드 기록을 다루는 17개의 도구.
 3. **Layer 2: 안전 검증** — 민감한 작업 실행 전 내부 논리 검사로 데이터 일관성 보장.
 4. **Layer 3: CLI 폴백** — MCP 서버를 사용할 수 없을 때 에이전트는 내장 `qp.bundle.js` 스크립트로 전환하여 데이터베이스에 직접 액세스.
 
@@ -52,7 +52,7 @@ QuickPrompt Skill에는 안정적인 운영을 보장하는 내장 안전 로직
 
 ### 🔌 AI 에이전트 파워 (신규!)
 
-- **🔌 21개의 MCP 도구**: AI 에이전트를 위한 완전한 프롬프트 관리 도구 모음.
+- **🔌 17개의 MCP 도구**: AI 에이전트를 위한 완전한 프롬프트 관리 도구 모음.
 - **🛡️ 액션 의사결정 트리**: 에이전트가 연결되고 안전한 경우에만 작동.
 - **📦 CLI 폴백 번들**: 오프라인 시나리오에서 사용할 수 있는 내장 스크립트.
 - **⚙️ 인터랙티브 설정 패널**: Cursor, Copilot, Cline, Claude 등 주요 도구의 쉬운 설정.
@@ -272,6 +272,14 @@ Quick Prompt v0.5.1은 확장 명령을 `quickPrompt.*` 네임스페이스로 �
 - **VirtualTabs**: 디렉토리 전체에서 어떤 파일이 어떤 작업에 속하는지 정리
 
 [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=winterdrive.virtual-tabs) | [**Open VSX Registry**](https://open-vsx.org/extension/winterdrive/virtual-tabs) 에서 얻기
+
+### 🔁 Edo Tensei
+
+**옮겨야 할 것이 생각뿐 아니라 세션 자체일 때.**
+
+Quick Prompt는 세션 *안에서* 떠오르는 생각을 버퍼링합니다. [Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei)는 할당량이 소진되거나 에이전트가 작업 도중 멈췄을 때 세션을 IDE *간에* 옮깁니다.
+
+[**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) | [**Open VSX Registry**](https://open-vsx.org/extension/Pain-Labs/edo-tensei)에서 Edo Tensei 받기
 
 ---
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -34,7 +34,7 @@
 QuickPrompt Skill 内置防呆与安全逻辑，确保 AI 在执行时稳定可靠：
 
 1. **Layer 0: 连接网关 (Connection Gate)** — 自动通过 `list_prompts` 测试连接。若 MCP 断开连接，Agent 会立即触发 HALT 刹车并询问用户是否降级处理。
-2. **Layer 1: 标准 MCP 工具** — 提供 21 个工具，涵盖 Prompt 的增删改查、版本历史与隐私遮罩。
+2. **Layer 1: 标准 MCP 工具** — 提供 17 个工具，涵盖 Prompt 的增删改查、版本历史与剪贴簿历史。
 3. **Layer 2: 安全验证** — 在执行敏感操作前进行二次逻辑检查，确保数据一致性。
 4. **Layer 3: CLI 后备 (Fallback CLI)** — 当 MCP server 无法使用时，Agent 可切换调用内置的 `qp.bundle.js` 脚本直接操作数据库。
 
@@ -52,7 +52,7 @@ QuickPrompt Skill 内置防呆与安全逻辑，确保 AI 在执行时稳定可�
 
 ### 🔌 AI Agent 强大武装 (新功能!)
 
-- **🔌 21 个 MCP 工具**：为 AI Agent 提供完整的 Prompt 管理工具箱。
+- **🔌 17 个 MCP 工具**：为 AI Agent 提供完整的 Prompt 管理工具箱。
 - **🛡️ 行动决策树**：确保 Agent 只在连接安全且逻辑通顺时执行变更。
 - **📦 CLI 后备脚本**：断线时可改用内置脚本，放在 generated skill 文件夹内。
 - **⚙️ 交互式设置面板**：轻松完成各类 AI 工具的环境配置。
@@ -271,6 +271,14 @@ Quick Prompt v0.5.1 将扩展功能命令统一到 `quickPrompt.*` namespace。C
 - **VirtualTabs**：跨任何目录，整理哪些文件属于哪个任务
 
 在 [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=winterdrive.virtual-tabs) | [**Open VSX Registry**](https://open-vsx.org/extension/winterdrive/virtual-tabs) 取得 VirtualTabs
+
+### 🔁 Edo Tensei
+
+**当需要搬动的不只是你的想法，而是整个 session 本身。**
+
+Quick Prompt 帮你缓冲的是 session *内部*正在想的事。[Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei) 则是在额度用尽或 agent 中途崩溃时，把 session *跨* IDE 搬过去。
+
+在 [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) | [**Open VSX Registry**](https://open-vsx.org/extension/Pain-Labs/edo-tensei) 取得 Edo Tensei
 
 ---
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -34,7 +34,7 @@
 QuickPrompt Skill 內建防呆與安全邏輯，確保 AI 在執行時穩定可靠：
 
 1. **Layer 0: 連線閘門 (Connection Gate)** — 自動透過 `list_prompts` 測試連線。若 MCP 斷線，Agent 會立即觸發 HALT 煞車並詢問用戶是否降級處理。
-2. **Layer 1: 標準 MCP 工具** — 提供 21 個工具，涵蓋 Prompt 的增刪改查、版本歷史與隱私遮罩。
+2. **Layer 1: 標準 MCP 工具** — 提供 17 個工具，涵蓋 Prompt 的增刪改查、版本歷史與剪貼簿歷史。
 3. **Layer 2: 安全驗證** — 在執行敏感操作前進行二次邏輯檢查，確保資料一致性。
 4. **Layer 3: CLI 後備 (Fallback CLI)** — 當 MCP server 無法使用時，Agent 可切換呼叫內建的 `qp.bundle.js` 腳本直接操作資料庫。
 
@@ -52,7 +52,7 @@ QuickPrompt Skill 內建防呆與安全邏輯，確保 AI 在執行時穩定可�
 
 ### 🔌 AI Agent 強大武裝 (New!)
 
-- **🔌 21 個 MCP 工具**：為 AI Agent 提供完整的 Prompt 管理工具箱。
+- **🔌 17 個 MCP 工具**：為 AI Agent 提供完整的 Prompt 管理工具箱。
 - **🛡️ 行動決策樹**：確保 Agent 只在連線安全且邏輯通順時執行變更。
 - **📦 CLI 後備腳本**：斷線時可改用內建腳本，放在 generated skill 資料夾內。
 - **⚙️ 互動式設定面板**：輕鬆完成各類 AI 工具的環境配置。
@@ -251,6 +251,14 @@ QuickPrompt Skill 內建防呆與安全邏輯，確保 AI 在執行時穩定可�
 - **VirtualTabs**：跨任何目錄，整理哪些檔案屬於哪個任務
 
 在 [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=winterdrive.virtual-tabs) | [**Open VSX Registry**](https://open-vsx.org/extension/winterdrive/virtual-tabs) 取得 VirtualTabs
+
+### 🔁 Edo Tensei
+
+**當需要搬動的不只是你的想法，而是整個 session 本身。**
+
+Quick Prompt 幫你緩衝的是 session *之內*正在想的事。[Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei) 則是在額度用盡或 agent 中途當機時，把 session *跨* IDE 搬過去。
+
+在 [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) | [**Open VSX Registry**](https://open-vsx.org/extension/Pain-Labs/edo-tensei) 取得 Edo Tensei
 
 ---
 

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -3,7 +3,7 @@
  *
  * This file is responsible for:
  * - Initializing the low-level MCP Server (Logging / Prompts / Resources / Tools)
- * - Registering 14 tools covering prompt CRUD and version history
+ * - Registering 17 tools covering prompt CRUD, version history, and clipboard
  * - Handling tool call requests and routing them to Tool classes
  * - Supporting the MCP Roots protocol for dynamically obtaining the workspace path
  * - Structured MCP Logging


### PR DESCRIPTION
## Summary
- 修正 README 宣稱的 MCP 工具數與實際不符的問題
- 移除已不存在的「隱私遮罩（privacy masking）」工具敘述（privacy masking 目前是 MCP Resource 提示文字，不是可呼叫的 Tool）
- 新增 Edo Tensei 作為第二個推薦 companion

## Changes

### MCP 工具數修正（全 5 語言 + server.ts）
- 「21 個工具，涵蓋 CRUD、版本歷史與隱私遮罩」→「17 個工具，涵蓋 CRUD、版本歷史與剪貼簿歷史」
- `mcp-server/src/server.ts` 檔頭註解：「Registering 14 tools...」→「Registering 17 tools covering prompt CRUD, version history, and clipboard」

### 新增 Edo Tensei companion（全 5 語言）
- 「Recommended Companion」→「Recommended Companions」
- 新增 Edo Tensei 介紹段落 + Marketplace / Open VSX 連結

## Test plan
- [ ] 確認 17 這個數字與目前 `TOOL_DEFS` 實際註冊工具數一致